### PR TITLE
[backend] 양도 글 안전시설 추가 기능 구현

### DIFF
--- a/BE/house/src/main/java/com/nextsquad/house/domain/house/RentArticle.java
+++ b/BE/house/src/main/java/com/nextsquad/house/domain/house/RentArticle.java
@@ -55,5 +55,7 @@ public class RentArticle {
     private boolean hasBalcony;
     @OneToMany(mappedBy = "rentArticle", fetch = FetchType.LAZY)
     private List<HouseImage> houseImages = new ArrayList<>();
+    @OneToMany(mappedBy = "rentArticle", fetch = FetchType.LAZY)
+    private List<RentArticleSecurityFacility> securityFacilities;
 
 }

--- a/BE/house/src/main/java/com/nextsquad/house/domain/house/RentArticleSecurityFacility.java
+++ b/BE/house/src/main/java/com/nextsquad/house/domain/house/RentArticleSecurityFacility.java
@@ -1,0 +1,26 @@
+package com.nextsquad.house.domain.house;
+
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor
+public class RentArticleSecurityFacility {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private RentArticle rentArticle;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private SecurityFacility securityFacility;
+
+    public RentArticleSecurityFacility(RentArticle rentArticle, SecurityFacility securityFacility) {
+        this.securityFacility = securityFacility;
+        this.rentArticle = rentArticle;
+    }
+}

--- a/BE/house/src/main/java/com/nextsquad/house/domain/house/SecurityFacility.java
+++ b/BE/house/src/main/java/com/nextsquad/house/domain/house/SecurityFacility.java
@@ -1,0 +1,14 @@
+package com.nextsquad.house.domain.house;
+
+import javax.persistence.*;
+
+@Entity
+
+public class SecurityFacility {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "security_facility_id")
+    private Long id;
+    private String name;
+}

--- a/BE/house/src/main/java/com/nextsquad/house/dto/RentArticleCreationRequest.java
+++ b/BE/house/src/main/java/com/nextsquad/house/dto/RentArticleCreationRequest.java
@@ -28,4 +28,5 @@ public class RentArticleCreationRequest {
     private boolean hasParkingLot;
     private boolean hasBalcony;
     private List<String> houseImages;
+    private List<String> securityFacilities;
 }

--- a/BE/house/src/main/java/com/nextsquad/house/repository/FacilityInHomeRepository.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/FacilityInHomeRepository.java
@@ -3,5 +3,5 @@ package com.nextsquad.house.repository;
 import com.nextsquad.house.domain.house.RentArticleFacility;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RentArticleFacilityRepository extends JpaRepository<RentArticleFacility, Long> {
+public interface FacilityInHomeRepository extends JpaRepository<RentArticleFacility, Long> {
 }

--- a/BE/house/src/main/java/com/nextsquad/house/repository/SecurityInHomeRepository.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/SecurityInHomeRepository.java
@@ -1,0 +1,9 @@
+package com.nextsquad.house.repository;
+
+import com.nextsquad.house.domain.house.RentArticleSecurityFacility;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SecurityInHomeRepository extends JpaRepository<RentArticleSecurityFacility, Long> {
+}

--- a/BE/house/src/main/java/com/nextsquad/house/repository/SecurityRepository.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/SecurityRepository.java
@@ -1,0 +1,12 @@
+package com.nextsquad.house.repository;
+
+import com.nextsquad.house.domain.house.SecurityFacility;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SecurityRepository extends JpaRepository<SecurityFacility, Long> {
+    Optional<SecurityFacility> findByName(String name);
+}

--- a/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
@@ -21,8 +21,10 @@ public class RentArticleService {
     private final RentArticleRepository rentArticleRepository;
     private final UserRepository userRepository;
     private final FacilityRepository facilityRepository;
-    private final RentArticleFacilityRepository rentArticleFacilityRepository;
+    private final FacilityInHomeRepository facilityInHomeRepository;
     private final HouseImageRepository houseImageRepository;
+    private final SecurityRepository securityRepository;
+    private final SecurityInHomeRepository securityInHomeRepository;
 
     public RentArticleCreationResponse writeRentArticle(RentArticleCreationRequest request){
         User user = userRepository.findById(request.getUserId()).orElseThrow();
@@ -55,7 +57,13 @@ public class RentArticleService {
         for (String facilityName : request.getFacilities()) {
             Facility facility = facilityRepository.findByName(facilityName)
                     .orElseThrow(() -> new RuntimeException());
-            rentArticleFacilityRepository.save(new RentArticleFacility(rentArticle, facility));
+            facilityInHomeRepository.save(new RentArticleFacility(rentArticle, facility));
+        }
+
+        for (String securityFacilityName : request.getSecurityFacilities()) {
+            SecurityFacility securityFacility = securityRepository.findByName(securityFacilityName)
+                    .orElseThrow(() -> new RuntimeException());
+            securityInHomeRepository.save(new RentArticleSecurityFacility(rentArticle, securityFacility));
         }
 
         return new RentArticleCreationResponse(rentArticle.getId());

--- a/BE/house/src/main/resources/data.sql
+++ b/BE/house/src/main/resources/data.sql
@@ -4,3 +4,6 @@ VALUES ( 1, 'street62',  'lee', 'KAKAO', 'lucas.com', 'MALE');
 
 INSERT INTO facility (facility_id, name)
 VALUES ( 1, '에어컨'), ( 2, '세탁기'), ( 3, '침대'), ( 4, '냉장고');
+
+INSERT INTO security_facility(security_facility_id, name)
+VALUES (1, 'CCTV'), (2, '비디오픈'), (3, '공동현관');


### PR DESCRIPTION
### Issue
#43 양도 글 작성시 안전시설 내용 추가

### 구현 내역
- 양도 글 내에 매물의 안전시설(SecurityFacility)를 추가할 수 있는 기능 구현
- 안전시설(cctv, 비디오픈 등) 엔티티 추가
- 양도글과 안전시설을 매핑하는 중간테이블(SecurityInHome) 생성
- 양도글 저장시 안전시설을 중간테이블에 저장함