### PR TITLE
[backend] 양도 글 상태변경(삭제, 완료처리) 및 찜하기 기능 구현

### DIFF
--- a/BE/house/src/main/java/com/nextsquad/house/controller/RentArticleController.java
+++ b/BE/house/src/main/java/com/nextsquad/house/controller/RentArticleController.java
@@ -39,9 +39,14 @@ public class RentArticleController {
         return ResponseEntity.ok(rentArticleService.deleteArticle(id));
     }
 
-    @PostMapping("/{id}")
-    public ResponseEntity<GeneralResponseDto> addBookmark(@PathVariable Long id, @RequestBody BookmarkRequestDto bookmarkRequestDto){
-        return ResponseEntity.ok(rentArticleService.addBookmark(id, bookmarkRequestDto));
+    @PostMapping("/bookmarks")
+    public ResponseEntity<GeneralResponseDto> addBookmark(@RequestBody BookmarkRequestDto bookmarkRequestDto){
+        return ResponseEntity.ok(rentArticleService.addBookmark(bookmarkRequestDto));
+    }
+
+    @DeleteMapping("/bookmarks")
+    public ResponseEntity<GeneralResponseDto> deleteBookmark(@RequestBody BookmarkRequestDto bookmarkRequestDto) {
+        return ResponseEntity.ok(rentArticleService.deleteBookmark(bookmarkRequestDto));
     }
 }
 

--- a/BE/house/src/main/java/com/nextsquad/house/controller/RentArticleController.java
+++ b/BE/house/src/main/java/com/nextsquad/house/controller/RentArticleController.java
@@ -1,6 +1,7 @@
 package com.nextsquad.house.controller;
 
 import com.nextsquad.house.dto.*;
+import com.nextsquad.house.dto.bookmark.BookmarkRequestDto;
 import com.nextsquad.house.service.RentArticleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -36,6 +37,11 @@ public class RentArticleController {
     @DeleteMapping("/{id}")
     public ResponseEntity<GeneralResponseDto> deleteArticle(@PathVariable Long id) {
         return ResponseEntity.ok(rentArticleService.deleteArticle(id));
+    }
+
+    @PostMapping("/{id}")
+    public ResponseEntity<GeneralResponseDto> addBookmark(@PathVariable Long id, @RequestBody BookmarkRequestDto bookmarkRequestDto){
+        return ResponseEntity.ok(rentArticleService.addBookmark(id, bookmarkRequestDto));
     }
 }
 

--- a/BE/house/src/main/java/com/nextsquad/house/controller/RentArticleController.java
+++ b/BE/house/src/main/java/com/nextsquad/house/controller/RentArticleController.java
@@ -1,9 +1,6 @@
 package com.nextsquad.house.controller;
 
-import com.nextsquad.house.dto.RentArticleCreationRequest;
-import com.nextsquad.house.dto.RentArticleCreationResponse;
-import com.nextsquad.house.dto.RentArticleListResponse;
-import com.nextsquad.house.dto.RentArticleResponse;
+import com.nextsquad.house.dto.*;
 import com.nextsquad.house.service.RentArticleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -29,7 +26,16 @@ public class RentArticleController {
     @GetMapping("/{id}")
     public ResponseEntity<RentArticleResponse> getRentArticle(@PathVariable Long id) {
         return ResponseEntity.ok(rentArticleService.getRentArticle(id));
+    }
 
+    @PatchMapping("/{id}/isCompleted")
+    public ResponseEntity<GeneralResponseDto> toggleIsCompleted(@PathVariable Long id) {
+        return ResponseEntity.ok(rentArticleService.toggleIsCompleted(id));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<GeneralResponseDto> deleteArticle(@PathVariable Long id) {
+        return ResponseEntity.ok(rentArticleService.deleteArticle(id));
     }
 }
 

--- a/BE/house/src/main/java/com/nextsquad/house/controller/UserController.java
+++ b/BE/house/src/main/java/com/nextsquad/house/controller/UserController.java
@@ -1,8 +1,10 @@
 package com.nextsquad.house.controller;
 
 import com.nextsquad.house.dto.GeneralResponseDto;
+import com.nextsquad.house.dto.bookmark.RentBookmarkElement;
 import com.nextsquad.house.dto.UserInfoDto;
 import com.nextsquad.house.dto.UserResponseDto;
+import com.nextsquad.house.dto.bookmark.RentBookmarkListResponse;
 import com.nextsquad.house.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +17,7 @@ public class UserController {
 
     private final UserService userService;
 
+
     @GetMapping("/{userId}")
     public ResponseEntity<UserResponseDto> getUserInfo(@PathVariable long userId) {
         return ResponseEntity.ok(userService.getUserInfo(userId));
@@ -23,6 +26,11 @@ public class UserController {
     @PatchMapping("/{userId}")
     public ResponseEntity<GeneralResponseDto> modifyUserInfo(@PathVariable long userId, @RequestBody UserInfoDto userInfoDto) {
         return ResponseEntity.ok(userService.modifyUserInfo(userId, userInfoDto));
+    }
+
+    @GetMapping("/{userId}/bookmarks/rent")
+    public ResponseEntity<RentBookmarkListResponse> getRentBookmark(@PathVariable long userId){
+        return ResponseEntity.ok(userService.getRentBookmark(userId));
     }
 
 }

--- a/BE/house/src/main/java/com/nextsquad/house/domain/house/RentArticle.java
+++ b/BE/house/src/main/java/com/nextsquad/house/domain/house/RentArticle.java
@@ -60,7 +60,8 @@ public class RentArticle {
     private boolean isDeleted;
     @OneToMany(mappedBy = "rentArticle", fetch = FetchType.LAZY)
     private List<HouseImage> houseImages = new ArrayList<>();
-
+    @OneToMany(mappedBy = "rentArticle", fetch = FetchType.LAZY)
+    private List<RentArticleBookmark> bookmarks = new ArrayList<>();
     public HouseImage getMainImage() {
         return houseImages.get(0);
     }

--- a/BE/house/src/main/java/com/nextsquad/house/domain/house/RentArticle.java
+++ b/BE/house/src/main/java/com/nextsquad/house/domain/house/RentArticle.java
@@ -72,4 +72,8 @@ public class RentArticle {
     public void markAsDeleted() {
         isDeleted = true;
     }
+
+    public void addViewCount(){
+        viewCount++;
+    }
 }

--- a/BE/house/src/main/java/com/nextsquad/house/domain/house/RentArticle.java
+++ b/BE/house/src/main/java/com/nextsquad/house/domain/house/RentArticle.java
@@ -64,4 +64,12 @@ public class RentArticle {
     public HouseImage getMainImage() {
         return houseImages.get(0);
     }
+
+    public void toggleIsCompleted() {
+        isCompleted = !isCompleted;
+    }
+
+    public void markAsDeleted() {
+        isDeleted = true;
+    }
 }

--- a/BE/house/src/main/java/com/nextsquad/house/domain/house/RentArticleBookmark.java
+++ b/BE/house/src/main/java/com/nextsquad/house/domain/house/RentArticleBookmark.java
@@ -1,0 +1,30 @@
+package com.nextsquad.house.domain.house;
+
+import com.nextsquad.house.domain.user.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class RentArticleBookmark {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private RentArticle rentArticle;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private User user;
+
+    public RentArticleBookmark(RentArticle rentArticle, User user) {
+        this.rentArticle = rentArticle;
+        this.user = user;
+    }
+}

--- a/BE/house/src/main/java/com/nextsquad/house/domain/user/User.java
+++ b/BE/house/src/main/java/com/nextsquad/house/domain/user/User.java
@@ -1,11 +1,14 @@
 package com.nextsquad.house.domain.user;
 
+import com.nextsquad.house.domain.house.RentArticleBookmark;
 import com.nextsquad.house.dto.UserInfoDto;
 import com.nextsquad.house.login.oauth.OauthClientType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor
 @Getter
@@ -22,6 +25,9 @@ public class User {
     private Gender gender;
     @Enumerated(EnumType.STRING)
     private OauthClientType oauthClientType;
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    private List<RentArticleBookmark> rentArticleBookmarkList = new ArrayList<>();
 
     public User(String accountId, String displayName, String profileImageUrl, OauthClientType oauthClientType) {
         this.accountId = accountId;

--- a/BE/house/src/main/java/com/nextsquad/house/dto/RentArticleListElement.java
+++ b/BE/house/src/main/java/com/nextsquad/house/dto/RentArticleListElement.java
@@ -20,6 +20,7 @@ public class RentArticleListElement {
     private Integer deposit;
     private Integer rentFee;
     private LocalDate availableFrom;
+    private Integer bookmarkCount;
     private LocalDate contractExpiresAt;
     private LocalDateTime createdAt;
     private boolean isCompleted;
@@ -34,6 +35,7 @@ public class RentArticleListElement {
                 .deposit(article.getDeposit())
                 .rentFee(article.getRentFee())
                 .availableFrom(article.getAvailableFrom())
+                .bookmarkCount(article.getBookmarks().size())
                 .contractExpiresAt(article.getContractExpiresAt())
                 .createdAt(article.getCreatedAt())
                 .isCompleted(article.isCompleted())

--- a/BE/house/src/main/java/com/nextsquad/house/dto/RentArticleListElement.java
+++ b/BE/house/src/main/java/com/nextsquad/house/dto/RentArticleListElement.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 public class RentArticleListElement {
+    private Long id;
     private String title;
     private String houseImage;
     private ContractType contractType;
@@ -26,6 +27,7 @@ public class RentArticleListElement {
 
     public static RentArticleListElement from(RentArticle article) {
         return RentArticleListElement.builder()
+                .id(article.getId())
                 .title(article.getTitle())
                 .houseImage(article.getMainImage().getImageUrl())
                 .contractType(article.getContractType())

--- a/BE/house/src/main/java/com/nextsquad/house/dto/RentArticleResponse.java
+++ b/BE/house/src/main/java/com/nextsquad/house/dto/RentArticleResponse.java
@@ -17,6 +17,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 public class RentArticleResponse {
+    private Long id;
     private Long userId;
     private String address;
     private String addressDetail;
@@ -46,7 +47,8 @@ public class RentArticleResponse {
 
     @Builder
     public RentArticleResponse(RentArticle rentArticle) {
-        this.userId = rentArticle.getId();
+        this.id = rentArticle.getId();
+        this.userId = rentArticle.getUser().getId();
         this.address = rentArticle.getAddress();
         this.addressDetail = rentArticle.getAddressDetail();
         this.title = rentArticle.getTitle();

--- a/BE/house/src/main/java/com/nextsquad/house/dto/RentArticleResponse.java
+++ b/BE/house/src/main/java/com/nextsquad/house/dto/RentArticleResponse.java
@@ -31,6 +31,7 @@ public class RentArticleResponse {
     private int maintenanceFee;
     private LocalDate availableFrom;
     private LocalDate contractExpiresAt;
+    private int bookmarkCount;
     private int maxFloor;
     private int thisFloor;
     private boolean hasParkingLot;
@@ -61,6 +62,7 @@ public class RentArticleResponse {
         this.maintenanceFee = rentArticle.getMaintenanceFee();
         this.availableFrom = rentArticle.getAvailableFrom();
         this.contractExpiresAt = rentArticle.getContractExpiresAt();
+        this.bookmarkCount = rentArticle.getBookmarks().size();
         this.maxFloor = rentArticle.getMaxFloor();
         this.thisFloor = rentArticle.getThisFloor();
         this.hasParkingLot = rentArticle.isHasParkingLot();

--- a/BE/house/src/main/java/com/nextsquad/house/dto/bookmark/BookmarkRequestDto.java
+++ b/BE/house/src/main/java/com/nextsquad/house/dto/bookmark/BookmarkRequestDto.java
@@ -1,0 +1,8 @@
+package com.nextsquad.house.dto.bookmark;
+
+import lombok.Getter;
+
+@Getter
+public class BookmarkRequestDto {
+    private Long userId;
+}

--- a/BE/house/src/main/java/com/nextsquad/house/dto/bookmark/BookmarkRequestDto.java
+++ b/BE/house/src/main/java/com/nextsquad/house/dto/bookmark/BookmarkRequestDto.java
@@ -5,4 +5,5 @@ import lombok.Getter;
 @Getter
 public class BookmarkRequestDto {
     private Long userId;
+    private Long articleId;
 }

--- a/BE/house/src/main/java/com/nextsquad/house/dto/bookmark/RentBookmarkElement.java
+++ b/BE/house/src/main/java/com/nextsquad/house/dto/bookmark/RentBookmarkElement.java
@@ -1,0 +1,38 @@
+package com.nextsquad.house.dto.bookmark;
+
+import com.nextsquad.house.domain.house.ContractType;
+import com.nextsquad.house.domain.house.RentArticleBookmark;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RentBookmarkElement {
+    private Long id;
+    private String title;
+    private ContractType contractType;
+    private int deposit;
+    private int rentFee;
+    private String mainImage;
+    private LocalDate availableFrom;
+    private LocalDate contractExpiresAt;
+    private int bookmarkCount;
+
+    //TODO: 북마크 count도 가져오기
+    public static RentBookmarkElement from (RentArticleBookmark rentArticleBookmark) {
+        return RentBookmarkElement.builder()
+                .id(rentArticleBookmark.getId())
+                .title(rentArticleBookmark.getRentArticle().getTitle())
+                .contractType(rentArticleBookmark.getRentArticle().getContractType())
+                .deposit(rentArticleBookmark.getRentArticle().getDeposit())
+                .rentFee(rentArticleBookmark.getRentArticle().getRentFee())
+                .mainImage(rentArticleBookmark.getRentArticle().getMainImage().getImageUrl())
+                .availableFrom(rentArticleBookmark.getRentArticle().getAvailableFrom())
+                .contractExpiresAt(rentArticleBookmark.getRentArticle().getContractExpiresAt())
+                .build();
+    }
+}

--- a/BE/house/src/main/java/com/nextsquad/house/dto/bookmark/RentBookmarkListResponse.java
+++ b/BE/house/src/main/java/com/nextsquad/house/dto/bookmark/RentBookmarkListResponse.java
@@ -1,0 +1,18 @@
+package com.nextsquad.house.dto.bookmark;
+
+import com.nextsquad.house.domain.house.RentArticleBookmark;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public class RentBookmarkListResponse {
+    private List<RentBookmarkElement> rentBookmarkList;
+
+    public static RentBookmarkListResponse from(List<RentArticleBookmark> bookmarks) {
+        return new RentBookmarkListResponse(bookmarks.stream().map(RentBookmarkElement::from).collect(Collectors.toList()));
+    }
+}

--- a/BE/house/src/main/java/com/nextsquad/house/repository/RentArticleBookmarkRepository.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/RentArticleBookmarkRepository.java
@@ -1,0 +1,12 @@
+package com.nextsquad.house.repository;
+
+import com.nextsquad.house.domain.house.RentArticleBookmark;
+import com.nextsquad.house.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RentArticleBookmarkRepository extends JpaRepository<RentArticleBookmark, Long> {
+
+    List<RentArticleBookmark> findByUser(User user);
+}

--- a/BE/house/src/main/java/com/nextsquad/house/repository/RentArticleBookmarkRepository.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/RentArticleBookmarkRepository.java
@@ -1,5 +1,6 @@
 package com.nextsquad.house.repository;
 
+import com.nextsquad.house.domain.house.RentArticle;
 import com.nextsquad.house.domain.house.RentArticleBookmark;
 import com.nextsquad.house.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,6 @@ import java.util.List;
 public interface RentArticleBookmarkRepository extends JpaRepository<RentArticleBookmark, Long> {
 
     List<RentArticleBookmark> findByUser(User user);
+
+    RentArticleBookmark findByUserAndRentArticle(User user, RentArticle rentArticle);
 }

--- a/BE/house/src/main/java/com/nextsquad/house/repository/RentArticleRepository.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/RentArticleRepository.java
@@ -1,6 +1,8 @@
 package com.nextsquad.house.repository;
 
 import com.nextsquad.house.domain.house.RentArticle;
+import com.nextsquad.house.domain.house.RentArticleBookmark;
+import com.nextsquad.house.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 

--- a/BE/house/src/main/java/com/nextsquad/house/repository/RentArticleRepository.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/RentArticleRepository.java
@@ -2,6 +2,11 @@ package com.nextsquad.house.repository;
 
 import com.nextsquad.house.domain.house.RentArticle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface RentArticleRepository extends JpaRepository<RentArticle, Long> {
+    @Query("select r from RentArticle r where r.isDeleted = false and r.isCompleted = false")
+    List<RentArticle> findAllAvailable();
 }

--- a/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
@@ -87,6 +87,8 @@ public class RentArticleService {
         if (rentArticle.isDeleted() || rentArticle.isCompleted()) {
             throw new RuntimeException("삭제되었거나 거래가 완료된 글입니다.");
         }
+        rentArticle.addViewCount();
+
         return new RentArticleResponse(rentArticle);
     }
 

--- a/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
@@ -111,6 +111,12 @@ public class RentArticleService {
     public GeneralResponseDto addBookmark(BookmarkRequestDto bookmarkRequestDto) {
         User user = userRepository.findById(bookmarkRequestDto.getUserId()).orElseThrow(() -> new RuntimeException());
         RentArticle rentArticle = rentArticleRepository.findById(bookmarkRequestDto.getArticleId()).orElseThrow(() -> new RuntimeException());
+        if (rentArticle.isDeleted()) {
+            return new GeneralResponseDto(400, "삭제된 게시글은 추가할 수 없습니다.");
+        }
+        if (rentArticle.isCompleted()) {
+            return new GeneralResponseDto(400, "완료된 게시글은 추가할 수 없습니다.");
+        }
         rentArticleBookmarkRepository.save(new RentArticleBookmark(rentArticle, user));
         return new GeneralResponseDto(200, "북마크에 추가 되었습니다.");
     }

--- a/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
@@ -3,6 +3,7 @@ package com.nextsquad.house.service;
 import com.nextsquad.house.domain.house.*;
 import com.nextsquad.house.domain.user.User;
 import com.nextsquad.house.dto.*;
+import com.nextsquad.house.dto.bookmark.BookmarkRequestDto;
 import com.nextsquad.house.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,6 +27,7 @@ public class RentArticleService {
     private final HouseImageRepository houseImageRepository;
     private final SecurityRepository securityRepository;
     private final SecurityInHomeRepository securityInHomeRepository;
+    private final RentArticleBookmarkRepository rentArticleBookmarkRepository;
 
     public RentArticleCreationResponse writeRentArticle(RentArticleCreationRequest request){
         User user = userRepository.findById(request.getUserId()).orElseThrow();
@@ -104,5 +106,12 @@ public class RentArticleService {
                 .orElseThrow(() -> new RuntimeException());
         rentArticle.markAsDeleted();
         return new GeneralResponseDto(200, "게시글이 삭제되었습니다.");
+    }
+
+    public GeneralResponseDto addBookmark(Long id, BookmarkRequestDto bookmarkRequestDto) {
+        User user = userRepository.findById(bookmarkRequestDto.getUserId()).orElseThrow(() -> new RuntimeException());
+        RentArticle rentArticle = rentArticleRepository.findById(id).orElseThrow(() -> new RuntimeException());
+        rentArticleBookmarkRepository.save(new RentArticleBookmark(rentArticle, user));
+        return new GeneralResponseDto(200, "북마크에 추가 되었습니다.");
     }
 }

--- a/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
@@ -108,10 +108,20 @@ public class RentArticleService {
         return new GeneralResponseDto(200, "게시글이 삭제되었습니다.");
     }
 
-    public GeneralResponseDto addBookmark(Long id, BookmarkRequestDto bookmarkRequestDto) {
+    public GeneralResponseDto addBookmark(BookmarkRequestDto bookmarkRequestDto) {
         User user = userRepository.findById(bookmarkRequestDto.getUserId()).orElseThrow(() -> new RuntimeException());
-        RentArticle rentArticle = rentArticleRepository.findById(id).orElseThrow(() -> new RuntimeException());
+        RentArticle rentArticle = rentArticleRepository.findById(bookmarkRequestDto.getArticleId()).orElseThrow(() -> new RuntimeException());
         rentArticleBookmarkRepository.save(new RentArticleBookmark(rentArticle, user));
         return new GeneralResponseDto(200, "북마크에 추가 되었습니다.");
+    }
+
+    public GeneralResponseDto deleteBookmark(BookmarkRequestDto bookmarkRequestDto) {
+        User user = userRepository.findById(bookmarkRequestDto.getUserId())
+                .orElseThrow(() -> new RuntimeException("해당 id에 맞는 유저가 없습니다."));
+        RentArticle rentArticle = rentArticleRepository.findById(bookmarkRequestDto.getArticleId())
+                .orElseThrow(() -> new RuntimeException("해당 id에 맞는 양도 게시글이 없습니다."));
+        RentArticleBookmark bookmark = rentArticleBookmarkRepository.findByUserAndRentArticle(user, rentArticle);
+        rentArticleBookmarkRepository.delete(bookmark);
+        return new GeneralResponseDto(200, "북마크가 삭제되었습니다.");
     }
 }

--- a/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
@@ -74,7 +74,7 @@ public class RentArticleService {
     }
 
     public RentArticleListResponse getRentArticles(String keyword, String sortedBy) {
-        List<RentArticle> rentArticles = rentArticleRepository.findAll();
+        List<RentArticle> rentArticles = rentArticleRepository.findAllAvailable();
         List<RentArticleListElement> responseElements = rentArticles.stream()
                 .map(RentArticleListElement::from)
                 .collect(Collectors.toList());
@@ -84,6 +84,9 @@ public class RentArticleService {
     
     public RentArticleResponse getRentArticle(Long id){
         RentArticle rentArticle = rentArticleRepository.findById(id).orElseThrow(() -> new RuntimeException());
+        if (rentArticle.isDeleted() || rentArticle.isCompleted()) {
+            throw new RuntimeException("삭제되었거나 거래가 완료된 글입니다.");
+        }
         return new RentArticleResponse(rentArticle);
     }
 

--- a/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
@@ -2,11 +2,7 @@ package com.nextsquad.house.service;
 
 import com.nextsquad.house.domain.house.*;
 import com.nextsquad.house.domain.user.User;
-import com.nextsquad.house.dto.RentArticleCreationRequest;
-import com.nextsquad.house.dto.RentArticleCreationResponse;
-import com.nextsquad.house.dto.RentArticleListElement;
-import com.nextsquad.house.dto.RentArticleListResponse;
-import com.nextsquad.house.dto.RentArticleResponse;
+import com.nextsquad.house.dto.*;
 import com.nextsquad.house.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -89,5 +85,19 @@ public class RentArticleService {
     public RentArticleResponse getRentArticle(Long id){
         RentArticle rentArticle = rentArticleRepository.findById(id).orElseThrow(() -> new RuntimeException());
         return new RentArticleResponse(rentArticle);
+    }
+
+    public GeneralResponseDto toggleIsCompleted(Long id) {
+        RentArticle rentArticle = rentArticleRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException());
+        rentArticle.toggleIsCompleted();
+        return new GeneralResponseDto(200, "게시글 상태가 변경되었습니다.");
+    }
+
+    public GeneralResponseDto deleteArticle(Long id) {
+        RentArticle rentArticle = rentArticleRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException());
+        rentArticle.markAsDeleted();
+        return new GeneralResponseDto(200, "게시글이 삭제되었습니다.");
     }
 }

--- a/BE/house/src/main/java/com/nextsquad/house/service/UserService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/UserService.java
@@ -1,14 +1,18 @@
 package com.nextsquad.house.service;
 
+import com.nextsquad.house.domain.house.RentArticleBookmark;
 import com.nextsquad.house.domain.user.User;
 import com.nextsquad.house.dto.GeneralResponseDto;
 import com.nextsquad.house.dto.UserInfoDto;
 import com.nextsquad.house.dto.UserResponseDto;
+import com.nextsquad.house.dto.bookmark.RentBookmarkListResponse;
+import com.nextsquad.house.repository.RentArticleBookmarkRepository;
 import com.nextsquad.house.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.List;
 
 @Service
 @Transactional
@@ -16,6 +20,7 @@ import javax.transaction.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final RentArticleBookmarkRepository rentArticleBookmarkRepository;
 
     public UserResponseDto getUserInfo(Long id) {
         User user = userRepository.findById(id).orElseThrow(() -> new RuntimeException("없는 유저 입니다."));
@@ -26,5 +31,11 @@ public class UserService {
         User user = userRepository.findById(id).orElseThrow();
         user.modifyInfo(userInfoDto);
         return new GeneralResponseDto(200, "정보가 수정되었습니다");
+    }
+
+    public RentBookmarkListResponse getRentBookmark(long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException());
+        List<RentArticleBookmark> bookmarks = rentArticleBookmarkRepository.findByUser(user);
+        return RentBookmarkListResponse.from(bookmarks);
     }
 }


### PR DESCRIPTION
## 관련 커밋
#53 #55

## 구현 내용
- 양도 글 삭제처리 구현
- 거래 완료/진행중 토글 기능 구현
- 양도 글 찜하기/해제 기능 구현
- 양도 글 로딩 시 찜하기 개수 반환하도록 함
- 삭제되거나 완료 처리된 게시글은 상세조회 및 찜하기 불가능하도록 함