### PR TITLE
[backend] 양도 글 수정 기능 구현

### DIFF
--- a/BE/house/src/main/java/com/nextsquad/house/controller/RentArticleController.java
+++ b/BE/house/src/main/java/com/nextsquad/house/controller/RentArticleController.java
@@ -15,8 +15,8 @@ public class RentArticleController {
     private final RentArticleService rentArticleService;
 
     @PostMapping
-    public ResponseEntity<RentArticleCreationResponse> writeRentArticle(@RequestBody RentArticleCreationRequest rentArticleCreationRequest){
-        return ResponseEntity.ok(rentArticleService.writeRentArticle(rentArticleCreationRequest));
+    public ResponseEntity<RentArticleCreationResponse> writeRentArticle(@RequestBody RentArticleRequest rentArticleRequest){
+        return ResponseEntity.ok(rentArticleService.writeRentArticle(rentArticleRequest));
     }
 
     @GetMapping
@@ -27,6 +27,11 @@ public class RentArticleController {
     @GetMapping("/{id}")
     public ResponseEntity<RentArticleResponse> getRentArticle(@PathVariable Long id) {
         return ResponseEntity.ok(rentArticleService.getRentArticle(id));
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<GeneralResponseDto> modifyRentArticle(@PathVariable Long id, @RequestBody RentArticleRequest request) {
+        return ResponseEntity.ok(rentArticleService.modifyRentArticle(id, request));
     }
 
     @PatchMapping("/{id}/isCompleted")

--- a/BE/house/src/main/java/com/nextsquad/house/domain/house/RentArticle.java
+++ b/BE/house/src/main/java/com/nextsquad/house/domain/house/RentArticle.java
@@ -1,6 +1,7 @@
 package com.nextsquad.house.domain.house;
 
 import com.nextsquad.house.domain.user.User;
+import com.nextsquad.house.dto.RentArticleRequest;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -77,5 +78,28 @@ public class RentArticle {
 
     public void addViewCount(){
         viewCount++;
+    }
+
+    public void modifyArticle(RentArticleRequest request) {
+        this.address = request.getAddress();
+        this.addressDetail = request.getAddressDetail();
+        this.addressDescription = request.getAddressDescription();
+        this.latitude = request.getLatitude();
+        this.longitude = request.getLongitude();
+        this.title = request.getTitle();
+        this.content = request.getContent();
+        this.contractType = ContractType.valueOf(request.getContractType());
+        this.houseType = HouseType.valueOf(request.getHouseType());
+        this.deposit = request.getDeposit();
+        this.rentFee = request.getRentFee();
+        this.maintenanceFee = request.getMaintenanceFee();
+        this.maintenanceFeeDescription = request.getMaintenanceFeeDescription();
+        this.availableFrom = request.getAvailableFrom();
+        this.contractExpiresAt = request.getContractExpiresAt();
+        this.maxFloor = request.getMaxFloor();
+        this.thisFloor = request.getThisFloor();
+        this.hasParkingLot = request.isHasParkingLot();
+        this.hasBalcony = request.isHasBalcony();
+        this.hasElevator = request.isHasElevator();
     }
 }

--- a/BE/house/src/main/java/com/nextsquad/house/dto/RentArticleRequest.java
+++ b/BE/house/src/main/java/com/nextsquad/house/dto/RentArticleRequest.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor
-public class RentArticleCreationRequest {
+public class RentArticleRequest {
 
     private Long userId;
     private String address;

--- a/BE/house/src/main/java/com/nextsquad/house/repository/FacilityInHomeRepository.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/FacilityInHomeRepository.java
@@ -1,7 +1,13 @@
 package com.nextsquad.house.repository;
 
+import com.nextsquad.house.domain.house.RentArticle;
 import com.nextsquad.house.domain.house.RentArticleFacility;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface FacilityInHomeRepository extends JpaRepository<RentArticleFacility, Long> {
+    @Modifying
+    @Query("delete from RentArticleFacility f where f.rentArticle = :rentArticle")
+    int deleteAllByRentArticle(RentArticle rentArticle);
 }

--- a/BE/house/src/main/java/com/nextsquad/house/repository/HouseImageRepository.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/HouseImageRepository.java
@@ -1,10 +1,18 @@
 package com.nextsquad.house.repository;
 
 import com.nextsquad.house.domain.house.HouseImage;
+import com.nextsquad.house.domain.house.RentArticle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface HouseImageRepository extends JpaRepository <HouseImage, Long> {
     List<HouseImage> findAllByImageUrlIn(List<String> imageUrls);
+
+    @Modifying
+    @Query("delete from HouseImage i where i.rentArticle = :rentArticle")
+    int deleteAllByArticle(@Param(value = "rentArticle") RentArticle rentArticle);
 }

--- a/BE/house/src/main/java/com/nextsquad/house/repository/SecurityInHomeRepository.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/SecurityInHomeRepository.java
@@ -1,9 +1,15 @@
 package com.nextsquad.house.repository;
 
+import com.nextsquad.house.domain.house.RentArticle;
 import com.nextsquad.house.domain.house.RentArticleSecurityFacility;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SecurityInHomeRepository extends JpaRepository<RentArticleSecurityFacility, Long> {
+    @Modifying
+    @Query("delete from RentArticleSecurityFacility f where f.rentArticle = :rentArticle")
+    int deleteAllByRentArticle(RentArticle rentArticle);
 }


### PR DESCRIPTION
## 연관 커밋
#59 

## 구현 내용
- 글 작성과 동일한 Request를 받아 필드를 재매핑함
- 중간 테이블은 요청한 RentArticle에 해당하는 레코드를 모두 삭제하고 다시 저장하는 방식.
- 중간 테이블 삭제 시 JPQL을 사용해 한 번에 특정 RentArticle과 매핑되는 레코드를 가져옴.