### PR TITLE
[backend] 회원 가입 시 닉네임 중복 체크 기능 구현

### DIFF
--- a/BE/house/src/main/java/com/nextsquad/house/controller/UserController.java
+++ b/BE/house/src/main/java/com/nextsquad/house/controller/UserController.java
@@ -4,6 +4,7 @@ import com.nextsquad.house.dto.GeneralResponseDto;
 import com.nextsquad.house.dto.RentArticleListResponse;
 import com.nextsquad.house.dto.UserInfoDto;
 import com.nextsquad.house.dto.UserResponseDto;
+import com.nextsquad.house.dto.user.DuplicationCheckResponse;
 import com.nextsquad.house.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +31,11 @@ public class UserController {
     @GetMapping("{userId}/bookmarks/rent")
     public ResponseEntity<RentArticleListResponse> getRentBookmark(@PathVariable long userId){
         return ResponseEntity.ok(userService.getRentBookmark(userId));
+    }
+
+    @GetMapping("/check-duplication")
+    public ResponseEntity<DuplicationCheckResponse> checkDuplication(@RequestParam String nickname) {
+        return ResponseEntity.ok(userService.checkDuplication(nickname));
     }
 
 }

--- a/BE/house/src/main/java/com/nextsquad/house/dto/user/DuplicationCheckResponse.java
+++ b/BE/house/src/main/java/com/nextsquad/house/dto/user/DuplicationCheckResponse.java
@@ -1,0 +1,10 @@
+package com.nextsquad.house.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DuplicationCheckResponse {
+    private Boolean isDuplicated;
+}

--- a/BE/house/src/main/java/com/nextsquad/house/login/userinfo/UserInfo.java
+++ b/BE/house/src/main/java/com/nextsquad/house/login/userinfo/UserInfo.java
@@ -5,7 +5,9 @@ import com.nextsquad.house.login.oauth.OauthClientType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@AllArgsConstructor
+import java.util.Random;
+import java.util.UUID;
+
 @Getter
 public class UserInfo {
     protected String accountId;
@@ -13,6 +15,15 @@ public class UserInfo {
 
     protected String profileImageUrl;
     private OauthClientType oauthClientType;
+
+    public UserInfo(String accountId, String displayName, String profileImageUrl, OauthClientType oauthClientType) {
+        String identifier = String.valueOf(new Random().nextInt(9999));
+
+        this.accountId = accountId;
+        this.displayName = displayName + identifier;
+        this.profileImageUrl = profileImageUrl;
+        this.oauthClientType = oauthClientType;
+    }
 
     public User toUser() {
         return new User(accountId, displayName, profileImageUrl, oauthClientType);

--- a/BE/house/src/main/java/com/nextsquad/house/repository/UserRepository.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/UserRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByAccountId(String accountId);
+
+    Boolean existsUserByDisplayName(String displayName);
 }

--- a/BE/house/src/main/java/com/nextsquad/house/service/UserService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/UserService.java
@@ -3,6 +3,7 @@ package com.nextsquad.house.service;
 import com.nextsquad.house.domain.house.RentArticleBookmark;
 import com.nextsquad.house.domain.user.User;
 import com.nextsquad.house.dto.*;
+import com.nextsquad.house.dto.user.DuplicationCheckResponse;
 import com.nextsquad.house.repository.RentArticleBookmarkRepository;
 import com.nextsquad.house.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -36,5 +37,9 @@ public class UserService {
         List<RentArticleBookmark> bookmarks = rentArticleBookmarkRepository.findByUser(user);
         List<RentArticleListElement> elements = bookmarks.stream().map(RentArticleListElement::from).collect(Collectors.toList());
         return new RentArticleListResponse(elements);
+    }
+
+    public DuplicationCheckResponse checkDuplication(String nickname) {
+        return new DuplicationCheckResponse(userRepository.existsUserByDisplayName(nickname));
     }
 }

--- a/BE/house/src/main/java/com/nextsquad/house/service/UserService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/UserService.java
@@ -28,6 +28,9 @@ public class UserService {
 
     public GeneralResponseDto modifyUserInfo(Long id, UserInfoDto userInfoDto){
         User user = userRepository.findById(id).orElseThrow();
+        if (userRepository.existsUserByDisplayName(userInfoDto.getDisplayName())) {
+            throw new IllegalArgumentException("중복된 닉네임 입니다.");
+        }
         user.modifyInfo(userInfoDto);
         return new GeneralResponseDto(200, "정보가 수정되었습니다");
     }


### PR DESCRIPTION
### Issue
#63 

### Description
- 회원 가입 시 닉네임에 4자리 랜덤 숫자 추가
- 유저 닉네임 중복 체크 기능 구현
- 유저 정보 수정 시 닉네임 중복이면 예외 발생하도록 구현