### PR TITLE
Feat: 양수 글 상세보기 기능 추가, 양수 글 생성 시 수정일 업데이트 버그 수정

### DIFF
--- a/BE/house/src/main/java/com/nextsquad/house/controller/WantedArticleController.java
+++ b/BE/house/src/main/java/com/nextsquad/house/controller/WantedArticleController.java
@@ -1,14 +1,12 @@
 package com.nextsquad.house.controller;
 
+import com.nextsquad.house.dto.wantedArticle.WantedArticleResponse;
 import com.nextsquad.house.dto.wantedArticle.SavedWantedArticleResponse;
 import com.nextsquad.house.dto.wantedArticle.WantedArticleRequest;
 import com.nextsquad.house.service.WantedArticleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,5 +18,11 @@ public class WantedArticleController {
     @PostMapping
     public ResponseEntity<SavedWantedArticleResponse> writeWantedArticle(@RequestBody WantedArticleRequest request) {
         return ResponseEntity.ok(wantedArticleService.writeWantedArticle(request));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<WantedArticleResponse> getWantedArticle(@PathVariable Long id) {
+        return ResponseEntity.ok(wantedArticleService.getWantedArticle(id));
+
     }
 }

--- a/BE/house/src/main/java/com/nextsquad/house/dto/UserInfoDto.java
+++ b/BE/house/src/main/java/com/nextsquad/house/dto/UserInfoDto.java
@@ -1,5 +1,6 @@
 package com.nextsquad.house.dto;
 
+import com.nextsquad.house.domain.user.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,4 +10,8 @@ public class UserInfoDto {
     private String displayName;
     private String profileImageUrl;
     private String gender;
+
+    public static UserInfoDto from(User user) {
+        return new UserInfoDto(user.getDisplayName(), user.getProfileImageUrl(), user.getGender().name());
+    }
 }

--- a/BE/house/src/main/java/com/nextsquad/house/dto/wantedArticle/WantedArticleResponse.java
+++ b/BE/house/src/main/java/com/nextsquad/house/dto/wantedArticle/WantedArticleResponse.java
@@ -1,0 +1,50 @@
+package com.nextsquad.house.dto.wantedArticle;
+
+import com.nextsquad.house.domain.house.WantedArticle;
+import com.nextsquad.house.dto.UserInfoDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Getter
+@Builder
+public class WantedArticleResponse {
+    private Long id;
+    private UserInfoDto user;
+    private String address;
+    private String title;
+    private String content;
+    private LocalDate moveInDate;
+    private LocalDate moveOutDate;
+    private int rentBudget;
+    private int depositBudget;
+    private int viewCount;
+    @DateTimeFormat(pattern = "yyyy-MM-dd:HH:mm:ss")
+    private LocalDateTime createdAt;
+    @DateTimeFormat(pattern = "yyyy-MM-dd:HH:mm:ss")
+    private LocalDateTime modifiedAt;
+
+    public static WantedArticleResponse from(WantedArticle article) {
+        UserInfoDto userInfoDto = UserInfoDto.from(article.getUser());
+        return WantedArticleResponse.builder()
+                .id(article.getId())
+                .user(userInfoDto)
+                .address(article.getAddress())
+                .title(article.getTitle())
+                .content(article.getContent())
+                .moveInDate(article.getMoveInDate())
+                .moveOutDate(article.getMoveOutDate())
+                .rentBudget(article.getRentBudget())
+                .depositBudget(article.getDepositBudget())
+                .viewCount(article.getViewCount())
+                .createdAt(article.getCreatedAt())
+                .modifiedAt(article.getModifiedAt())
+                .build();
+    }
+
+}

--- a/BE/house/src/main/java/com/nextsquad/house/service/WantedArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/WantedArticleService.java
@@ -4,6 +4,7 @@ import com.nextsquad.house.domain.house.WantedArticle;
 import com.nextsquad.house.domain.user.User;
 import com.nextsquad.house.dto.wantedArticle.SavedWantedArticleResponse;
 import com.nextsquad.house.dto.wantedArticle.WantedArticleRequest;
+import com.nextsquad.house.dto.wantedArticle.WantedArticleResponse;
 import com.nextsquad.house.repository.UserRepository;
 import com.nextsquad.house.repository.WantedArticleRepository;
 import lombok.RequiredArgsConstructor;
@@ -29,9 +30,16 @@ public class WantedArticleService {
                 .rentBudget(request.getRentBudget())
                 .depositBudget(request.getDepositBudget())
                 .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
                 .build();
 
         wantedArticleRepository.save(wantedArticle);
         return new SavedWantedArticleResponse(wantedArticle.getId());
+    }
+
+    public WantedArticleResponse getWantedArticle(Long articleId) {
+        WantedArticle article = wantedArticleRepository.findById(articleId)
+                .orElseThrow(() -> new IllegalArgumentException("요청하신 id에 해당하는 게시글이 없습니다."));
+        return WantedArticleResponse.from(article);
     }
 }


### PR DESCRIPTION
## 관련 커밋
#67 

## 구현사항
- WantedArticleResponse를 통한 양수 글 상세보기 기능 추가
- WantedArticleResponse 내에 UserInfoDto를 넣어 글쓴이의 닉네임, 프로필 이미지, 성별을 한꺼번에 받을 수 있도록 함.
- WantedArticle 생성 시 수정일 업데이트하도록 버그 수정