### PR TITLE
[backend] 양수글 찜하기 기능 구현

### DIFF
--- a/BE/house/src/main/java/com/nextsquad/house/controller/WantedArticleController.java
+++ b/BE/house/src/main/java/com/nextsquad/house/controller/WantedArticleController.java
@@ -1,6 +1,7 @@
 package com.nextsquad.house.controller;
 
 import com.nextsquad.house.dto.GeneralResponseDto;
+import com.nextsquad.house.dto.bookmark.BookmarkRequestDto;
 import com.nextsquad.house.dto.wantedArticle.WantedArticleResponse;
 import com.nextsquad.house.dto.wantedArticle.SavedWantedArticleResponse;
 import com.nextsquad.house.dto.wantedArticle.WantedArticleListResponse;
@@ -41,6 +42,11 @@ public class WantedArticleController {
     @DeleteMapping("/{id}")
     public ResponseEntity<GeneralResponseDto> deleteWantedArticle(@PathVariable Long id){
         return ResponseEntity.ok(wantedArticleService.deleteWantedArticle(id));
+    }
+
+    @PostMapping("/bookmarks")
+    public ResponseEntity<GeneralResponseDto> addWantedBookmark(@RequestBody BookmarkRequestDto bookmarkRequestDto) {
+        return ResponseEntity.ok(wantedArticleService.addWantedBookmark(bookmarkRequestDto));
     }
 
 }

--- a/BE/house/src/main/java/com/nextsquad/house/domain/house/WantedArticle.java
+++ b/BE/house/src/main/java/com/nextsquad/house/domain/house/WantedArticle.java
@@ -11,6 +11,8 @@ import org.springframework.format.annotation.DateTimeFormat;
 import javax.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -42,6 +44,8 @@ public class WantedArticle {
     private LocalDateTime modifiedAt;
     private boolean isDeleted;
 
+    @OneToMany(mappedBy = "wantedArticle")
+    private List<WantedArticleBookmark> bookmarks = new ArrayList<>();
 
     public void markAsDeleted(){
         isDeleted = true;

--- a/BE/house/src/main/java/com/nextsquad/house/domain/house/WantedArticleBookmark.java
+++ b/BE/house/src/main/java/com/nextsquad/house/domain/house/WantedArticleBookmark.java
@@ -1,0 +1,31 @@
+package com.nextsquad.house.domain.house;
+
+import com.nextsquad.house.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class WantedArticleBookmark {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private WantedArticle wantedArticle;
+
+    public WantedArticleBookmark(User user, WantedArticle wantedArticle) {
+        this.user = user;
+        this.wantedArticle = wantedArticle;
+    }
+}

--- a/BE/house/src/main/java/com/nextsquad/house/dto/wantedArticle/WantedArticleResponse.java
+++ b/BE/house/src/main/java/com/nextsquad/house/dto/wantedArticle/WantedArticleResponse.java
@@ -28,6 +28,7 @@ public class WantedArticleResponse {
     private LocalDateTime createdAt;
     @DateTimeFormat(pattern = "yyyy-MM-dd:HH:mm:ss")
     private LocalDateTime modifiedAt;
+    private int bookmarkCount;
 
     public static WantedArticleResponse from(WantedArticle article) {
         UserInfoDto userInfoDto = UserInfoDto.from(article.getUser());
@@ -44,6 +45,7 @@ public class WantedArticleResponse {
                 .viewCount(article.getViewCount())
                 .createdAt(article.getCreatedAt())
                 .modifiedAt(article.getModifiedAt())
+                .bookmarkCount(article.getBookmarks().size())
                 .build();
     }
 

--- a/BE/house/src/main/java/com/nextsquad/house/repository/WantedArticleBookmarkRepository.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/WantedArticleBookmarkRepository.java
@@ -1,0 +1,7 @@
+package com.nextsquad.house.repository;
+
+import com.nextsquad.house.domain.house.WantedArticleBookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WantedArticleBookmarkRepository extends JpaRepository<WantedArticleBookmark, Long> {
+}

--- a/BE/house/src/main/java/com/nextsquad/house/service/WantedArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/WantedArticleService.java
@@ -1,14 +1,17 @@
 package com.nextsquad.house.service;
 
 import com.nextsquad.house.domain.house.WantedArticle;
+import com.nextsquad.house.domain.house.WantedArticleBookmark;
 import com.nextsquad.house.domain.user.User;
 import com.nextsquad.house.dto.GeneralResponseDto;
+import com.nextsquad.house.dto.bookmark.BookmarkRequestDto;
 import com.nextsquad.house.dto.wantedArticle.WantedArticleElementResponse;
 import com.nextsquad.house.dto.wantedArticle.SavedWantedArticleResponse;
 import com.nextsquad.house.dto.wantedArticle.WantedArticleListResponse;
 import com.nextsquad.house.dto.wantedArticle.WantedArticleRequest;
 import com.nextsquad.house.dto.wantedArticle.WantedArticleResponse;
 import com.nextsquad.house.repository.UserRepository;
+import com.nextsquad.house.repository.WantedArticleBookmarkRepository;
 import com.nextsquad.house.repository.WantedArticleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,6 +28,7 @@ public class WantedArticleService {
 
     private final WantedArticleRepository wantedArticleRepository;
     private final UserRepository userRepository;
+    private final WantedArticleBookmarkRepository wantedArticleBookmarkRepository;
 
     public SavedWantedArticleResponse writeWantedArticle(WantedArticleRequest request) {
         User user = userRepository.findById(request.getUserId()).orElseThrow();
@@ -74,5 +78,15 @@ public class WantedArticleService {
 
         article.modifyArticle(request);
         return new GeneralResponseDto(200, "게시글이 수정되었습니다.");
+    }
+
+    public GeneralResponseDto addWantedBookmark(BookmarkRequestDto bookmarkRequestDto) {
+        WantedArticle wantedArticle = wantedArticleRepository.findById(bookmarkRequestDto.getArticleId())
+                .orElseThrow(() -> new RuntimeException("해당하는 ID의 게시글이 존재하지 않습니다"));
+        User user = userRepository.findById(bookmarkRequestDto.getUserId())
+                .orElseThrow(() -> new RuntimeException("해당 유저가 존재하지 않습니다"));
+
+        wantedArticleBookmarkRepository.save(new WantedArticleBookmark(user, wantedArticle));
+        return new GeneralResponseDto(200, "북마크에 추가 되었습니다.");
     }
 }


### PR DESCRIPTION
### Issue
#75

### Description
- 양수글 찜하기 관련 엔티티(WantedArticleBookmark) 생성 및 연관관계 매핑
- 양수글 찜하기 기능 구현
- 양수글 상세 보기 시 찜하기 갯수도 볼 수 있도록 해당 DTO(WantedArticleResponse) 수정