### PR TITLE
[backend] 양수/양도 글 검색 및 정렬 처리

### DIFF
--- a/BE/house/build.gradle
+++ b/BE/house/build.gradle
@@ -1,6 +1,12 @@
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
 plugins {
 	id 'org.springframework.boot' version '2.7.2'
 	id 'io.spring.dependency-management' version '1.0.12.RELEASE'
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 	id 'java'
 }
 
@@ -49,8 +55,28 @@ dependencies {
 
 	//s3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	//query dsl
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+//querydsl
+def querydslDir = "$buildDir/generated/querydsl"
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+sourceSets {
+	main.java.srcDir querydslDir
+}
+configurations {
+	querydsl.extendsFrom compileClasspath
+}
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
 }

--- a/BE/house/src/main/java/com/nextsquad/house/config/JpaQueryConfig.java
+++ b/BE/house/src/main/java/com/nextsquad/house/config/JpaQueryConfig.java
@@ -1,0 +1,19 @@
+package com.nextsquad.house.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class JpaQueryConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/BE/house/src/main/java/com/nextsquad/house/controller/RentArticleController.java
+++ b/BE/house/src/main/java/com/nextsquad/house/controller/RentArticleController.java
@@ -4,11 +4,13 @@ import com.nextsquad.house.dto.*;
 import com.nextsquad.house.dto.bookmark.BookmarkRequestDto;
 import com.nextsquad.house.service.RentArticleService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/houses/rent")
 public class RentArticleController {

--- a/BE/house/src/main/java/com/nextsquad/house/controller/RentArticleController.java
+++ b/BE/house/src/main/java/com/nextsquad/house/controller/RentArticleController.java
@@ -23,8 +23,8 @@ public class RentArticleController {
     }
 
     @GetMapping
-    public ResponseEntity<RentArticleListResponse> getRentArticles(@RequestParam String keyword, Pageable pageable) {
-        return ResponseEntity.ok(rentArticleService.getRentArticles(keyword, pageable));
+    public ResponseEntity<RentArticleListResponse> getRentArticles(@ModelAttribute SearchConditionDto searchCondition, Pageable pageable) {
+        return ResponseEntity.ok(rentArticleService.getRentArticles(searchCondition, pageable));
     }
 
     @GetMapping("/{id}")

--- a/BE/house/src/main/java/com/nextsquad/house/controller/RentArticleController.java
+++ b/BE/house/src/main/java/com/nextsquad/house/controller/RentArticleController.java
@@ -21,8 +21,8 @@ public class RentArticleController {
     }
 
     @GetMapping
-    public ResponseEntity<RentArticleListResponse> getRentArticles(Pageable pageable) {
-        return ResponseEntity.ok(rentArticleService.getRentArticles(pageable));
+    public ResponseEntity<RentArticleListResponse> getRentArticles(@RequestParam String keyword, Pageable pageable) {
+        return ResponseEntity.ok(rentArticleService.getRentArticles(keyword, pageable));
     }
 
     @GetMapping("/{id}")
@@ -54,5 +54,6 @@ public class RentArticleController {
     public ResponseEntity<GeneralResponseDto> deleteBookmark(@RequestBody BookmarkRequestDto bookmarkRequestDto) {
         return ResponseEntity.ok(rentArticleService.deleteBookmark(bookmarkRequestDto));
     }
+
 }
 

--- a/BE/house/src/main/java/com/nextsquad/house/controller/WantedArticleController.java
+++ b/BE/house/src/main/java/com/nextsquad/house/controller/WantedArticleController.java
@@ -36,8 +36,8 @@ public class WantedArticleController {
     }
 
     @GetMapping
-    public ResponseEntity<WantedArticleListResponse> getWantedArticleList(Pageable pageable) {
-        return ResponseEntity.ok(wantedArticleService.getWantedArticleList(pageable));
+    public ResponseEntity<WantedArticleListResponse> getWantedArticleList(@RequestParam String keyword, Pageable pageable) {
+        return ResponseEntity.ok(wantedArticleService.getWantedArticleList(keyword, pageable));
     }
 
     @DeleteMapping("/{id}")

--- a/BE/house/src/main/java/com/nextsquad/house/controller/WantedArticleController.java
+++ b/BE/house/src/main/java/com/nextsquad/house/controller/WantedArticleController.java
@@ -1,6 +1,7 @@
 package com.nextsquad.house.controller;
 
 import com.nextsquad.house.dto.GeneralResponseDto;
+import com.nextsquad.house.dto.SearchConditionDto;
 import com.nextsquad.house.dto.bookmark.BookmarkRequestDto;
 import com.nextsquad.house.dto.wantedArticle.WantedArticleResponse;
 import com.nextsquad.house.dto.wantedArticle.SavedWantedArticleResponse;
@@ -36,8 +37,8 @@ public class WantedArticleController {
     }
 
     @GetMapping
-    public ResponseEntity<WantedArticleListResponse> getWantedArticleList(@RequestParam String keyword, Pageable pageable) {
-        return ResponseEntity.ok(wantedArticleService.getWantedArticleList(keyword, pageable));
+    public ResponseEntity<WantedArticleListResponse> getWantedArticleList(@ModelAttribute SearchConditionDto searchConditionDto, Pageable pageable) {
+        return ResponseEntity.ok(wantedArticleService.getWantedArticleList(searchConditionDto, pageable));
     }
 
     @DeleteMapping("/{id}")

--- a/BE/house/src/main/java/com/nextsquad/house/domain/house/RentArticle.java
+++ b/BE/house/src/main/java/com/nextsquad/house/domain/house/RentArticle.java
@@ -103,3 +103,4 @@ public class RentArticle {
         this.hasElevator = request.isHasElevator();
     }
 }
+

--- a/BE/house/src/main/java/com/nextsquad/house/dto/SearchConditionDto.java
+++ b/BE/house/src/main/java/com/nextsquad/house/dto/SearchConditionDto.java
@@ -1,0 +1,16 @@
+package com.nextsquad.house.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SearchConditionDto {
+    private Boolean isCompleted;
+    private String sortedBy;
+    private String keyword;
+}

--- a/BE/house/src/main/java/com/nextsquad/house/dto/SearchRequest.java
+++ b/BE/house/src/main/java/com/nextsquad/house/dto/SearchRequest.java
@@ -1,0 +1,8 @@
+package com.nextsquad.house.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SearchRequest {
+    private String keyword;
+}

--- a/BE/house/src/main/java/com/nextsquad/house/dto/SearchRequest.java
+++ b/BE/house/src/main/java/com/nextsquad/house/dto/SearchRequest.java
@@ -1,8 +1,0 @@
-package com.nextsquad.house.dto;
-
-import lombok.Getter;
-
-@Getter
-public class SearchRequest {
-    private String keyword;
-}

--- a/BE/house/src/main/java/com/nextsquad/house/repository/CustomRentArticleRepository.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/CustomRentArticleRepository.java
@@ -1,11 +1,10 @@
 package com.nextsquad.house.repository;
 
 import com.nextsquad.house.domain.house.RentArticle;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface CustomRentArticleRepository {
-    List<RentArticle> findbyKeyword(String keyword, Pageable pageable);
+    List<RentArticle> findByKeyword(String keyword, Pageable pageable);
 }

--- a/BE/house/src/main/java/com/nextsquad/house/repository/CustomRentArticleRepository.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/CustomRentArticleRepository.java
@@ -1,10 +1,11 @@
 package com.nextsquad.house.repository;
 
 import com.nextsquad.house.domain.house.RentArticle;
+import com.nextsquad.house.dto.SearchConditionDto;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface CustomRentArticleRepository {
-    List<RentArticle> findByKeyword(String keyword, Pageable pageable);
+    List<RentArticle> findByKeyword(SearchConditionDto searchCondition, Pageable pageable);
 }

--- a/BE/house/src/main/java/com/nextsquad/house/repository/CustomRentArticleRepository.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/CustomRentArticleRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface CustomRentArticleRepository {
-    Page<RentArticle> findbyKeyword(String keyword, Pageable pageable);
+    List<RentArticle> findbyKeyword(String keyword, Pageable pageable);
 }

--- a/BE/house/src/main/java/com/nextsquad/house/repository/CustomRentArticleRepository.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/CustomRentArticleRepository.java
@@ -1,0 +1,11 @@
+package com.nextsquad.house.repository;
+
+import com.nextsquad.house.domain.house.RentArticle;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface CustomRentArticleRepository {
+    Page<RentArticle> findbyKeyword(String keyword, Pageable pageable);
+}

--- a/BE/house/src/main/java/com/nextsquad/house/repository/CustomRentArticleRepositoryImpl.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/CustomRentArticleRepositoryImpl.java
@@ -1,0 +1,53 @@
+package com.nextsquad.house.repository;
+
+import com.nextsquad.house.domain.house.RentArticle;
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPQLQueryFactory;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.nextsquad.house.domain.house.QRentArticle.rentArticle;
+
+@RequiredArgsConstructor
+public class CustomRentArticleRepositoryImpl implements CustomRentArticleRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public PageImpl<RentArticle> findbyKeyword(String keyword, Pageable pageable) {
+        List<RentArticle> content = jpaQueryFactory
+                .select(rentArticle)
+                .from(rentArticle)
+                .where(rentArticle.isCompleted.eq(false),
+                        rentArticle.isDeleted.eq(false),
+                        checkAddress(keyword),
+                        checkTitle(keyword))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+//                .fetchResults();
+                .fetch();
+
+//        return new PageImpl<>(content.getResults(), pageable, content.getTotal());
+        return new PageImpl<>(content, pageable, content.size());
+    }
+
+    private BooleanExpression checkAddress(String keyword) {
+        if (keyword == null) {
+            return null;
+        }
+        return rentArticle.address.like("%" + keyword + "%");
+    }
+
+    private BooleanExpression checkTitle(String keyword) {
+        if (keyword == null) {
+            return null;
+        }
+        return rentArticle.title.like("%" + keyword + "%");
+    }
+}

--- a/BE/house/src/main/java/com/nextsquad/house/repository/CustomRentArticleRepositoryImpl.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/CustomRentArticleRepositoryImpl.java
@@ -4,11 +4,13 @@ import com.nextsquad.house.domain.house.RentArticle;
 import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPQLQueryFactory;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
 
@@ -20,21 +22,18 @@ public class CustomRentArticleRepositoryImpl implements CustomRentArticleReposit
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public PageImpl<RentArticle> findbyKeyword(String keyword, Pageable pageable) {
+    public List<RentArticle> findbyKeyword(String keyword, Pageable pageable) {
         List<RentArticle> content = jpaQueryFactory
                 .select(rentArticle)
                 .from(rentArticle)
                 .where(rentArticle.isCompleted.eq(false),
                         rentArticle.isDeleted.eq(false),
-                        checkAddress(keyword),
-                        checkTitle(keyword))
+                        checkAddress(keyword).or(checkTitle(keyword)))
                 .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-//                .fetchResults();
+                .limit(pageable.getPageSize() + 1)
                 .fetch();
 
-//        return new PageImpl<>(content.getResults(), pageable, content.getTotal());
-        return new PageImpl<>(content, pageable, content.size());
+        return content;
     }
 
     private BooleanExpression checkAddress(String keyword) {

--- a/BE/house/src/main/java/com/nextsquad/house/repository/CustomRentArticleRepositoryImpl.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/CustomRentArticleRepositoryImpl.java
@@ -1,12 +1,16 @@
 package com.nextsquad.house.repository;
 
 import com.nextsquad.house.domain.house.RentArticle;
+import com.nextsquad.house.dto.SearchConditionDto;
 import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPQLQueryFactory;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -16,29 +20,40 @@ import java.util.List;
 
 import static com.nextsquad.house.domain.house.QRentArticle.rentArticle;
 
+@Slf4j
 @RequiredArgsConstructor
 public class CustomRentArticleRepositoryImpl implements CustomRentArticleRepository{
 
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<RentArticle> findByKeyword(String keyword, Pageable pageable) {
+    public List<RentArticle> findByKeyword(SearchConditionDto searchCondition, Pageable pageable) {
+        log.info("keyword: {}, isCompleted: {}, sortedBy: {}", searchCondition.getKeyword(), searchCondition.getIsCompleted(), searchCondition.getSortedBy());
         List<RentArticle> content = jpaQueryFactory
                 .select(rentArticle)
                 .from(rentArticle)
-                .where(rentArticle.isCompleted.eq(false),
-                        rentArticle.isDeleted.eq(false),
-                        checkAddress(keyword).or(checkTitle(keyword)))
+                .where(rentArticle.isDeleted.eq(false),
+                        checkAddressAndTitle(searchCondition.getKeyword()),
+                        checkIsCompleted(searchCondition.getIsCompleted()))
+
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
+                .orderBy(checkSortCondition(searchCondition.getSortedBy()))
                 .fetch();
 
         return content;
     }
 
-    private BooleanExpression checkAddress(String keyword) {
+    private BooleanExpression checkAddressAndTitle(String keyword) {
         if (keyword == null) {
             return null;
+        }
+        return (checkAddress(keyword)).or(checkTitle(keyword));
+    }
+
+    private BooleanExpression checkAddress(String keyword) {
+        if (keyword == null) {
+            return Expressions.asBoolean(false);
         }
         return rentArticle.address.like("%" + keyword + "%");
     }
@@ -48,5 +63,23 @@ public class CustomRentArticleRepositoryImpl implements CustomRentArticleReposit
             return null;
         }
         return rentArticle.title.like("%" + keyword + "%");
+    }
+
+    private BooleanExpression checkIsCompleted(Boolean isCompleted) {
+        if (isCompleted == null || !isCompleted) {
+            return rentArticle.isCompleted.eq(false);
+        }
+        return rentArticle.isCompleted.eq(true);
+    }
+
+    private OrderSpecifier checkSortCondition(String sortedBy) {
+        if (sortedBy == null) {
+            return rentArticle.createdAt.desc();
+        } else if (sortedBy.equals("rentFee")) {
+            return rentArticle.rentFee.asc();
+        } else if (sortedBy.equals("deposit")) {
+            return rentArticle.deposit.asc();
+        }
+        return rentArticle.createdAt.desc();
     }
 }

--- a/BE/house/src/main/java/com/nextsquad/house/repository/CustomRentArticleRepositoryImpl.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/CustomRentArticleRepositoryImpl.java
@@ -22,7 +22,7 @@ public class CustomRentArticleRepositoryImpl implements CustomRentArticleReposit
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<RentArticle> findbyKeyword(String keyword, Pageable pageable) {
+    public List<RentArticle> findByKeyword(String keyword, Pageable pageable) {
         List<RentArticle> content = jpaQueryFactory
                 .select(rentArticle)
                 .from(rentArticle)

--- a/BE/house/src/main/java/com/nextsquad/house/repository/CustomWantedArticleRepository.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/CustomWantedArticleRepository.java
@@ -2,10 +2,11 @@ package com.nextsquad.house.repository;
 
 import com.nextsquad.house.domain.house.RentArticle;
 import com.nextsquad.house.domain.house.WantedArticle;
+import com.nextsquad.house.dto.SearchConditionDto;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface CustomWantedArticleRepository {
-    List<WantedArticle> findByKeyword(String keyword, Pageable pageable);
+    List<WantedArticle> findByKeyword(SearchConditionDto searchCondition, Pageable pageable);
 }

--- a/BE/house/src/main/java/com/nextsquad/house/repository/CustomWantedArticleRepository.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/CustomWantedArticleRepository.java
@@ -1,0 +1,11 @@
+package com.nextsquad.house.repository;
+
+import com.nextsquad.house.domain.house.RentArticle;
+import com.nextsquad.house.domain.house.WantedArticle;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface CustomWantedArticleRepository {
+    List<WantedArticle> findByKeyword(String keyword, Pageable pageable);
+}

--- a/BE/house/src/main/java/com/nextsquad/house/repository/CustomWantedArticleRepositoryImpl.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/CustomWantedArticleRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.nextsquad.house.repository;
 
 import com.nextsquad.house.domain.house.RentArticle;
 import com.nextsquad.house.domain.house.WantedArticle;
+import com.nextsquad.house.dto.SearchConditionDto;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -18,14 +19,16 @@ public class CustomWantedArticleRepositoryImpl implements CustomWantedArticleRep
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<WantedArticle> findByKeyword(String keyword, Pageable pageable) {
-        log.info("keyword: {}", keyword);
+    public List<WantedArticle> findByKeyword(SearchConditionDto searchCondition, Pageable pageable) {
+
         List<WantedArticle> content = jpaQueryFactory
                 .select(wantedArticle)
                 .from(wantedArticle)
-                .where(wantedArticle.isCompleted.eq(false),
-                        wantedArticle.isDeleted.eq(false),
-                        checkAddress(keyword).or(checkTitle(keyword)))
+                .where(wantedArticle.isDeleted.eq(false),
+                        checkAddressAndTitle(searchCondition.getKeyword()),
+                        checkIsCompleted(searchCondition.getIsCompleted())
+                )
+                .orderBy(wantedArticle.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
@@ -33,6 +36,12 @@ public class CustomWantedArticleRepositoryImpl implements CustomWantedArticleRep
         return content;
     }
 
+    private BooleanExpression checkAddressAndTitle(String keyword) {
+        if (keyword == null) {
+            return null;
+        }
+        return (checkAddress(keyword).or(checkTitle(keyword)));
+    }
     private BooleanExpression checkAddress(String keyword) {
         if (keyword == null) {
             return null;
@@ -45,5 +54,12 @@ public class CustomWantedArticleRepositoryImpl implements CustomWantedArticleRep
             return null;
         }
         return wantedArticle.title.like("%" + keyword + "%");
+    }
+
+    private BooleanExpression checkIsCompleted(Boolean isCompleted) {
+        if (isCompleted == null || !isCompleted) {
+            return wantedArticle.isCompleted.eq(false);
+        }
+        return wantedArticle.isCompleted.eq(true);
     }
 }

--- a/BE/house/src/main/java/com/nextsquad/house/repository/CustomWantedArticleRepositoryImpl.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/CustomWantedArticleRepositoryImpl.java
@@ -1,0 +1,49 @@
+package com.nextsquad.house.repository;
+
+import com.nextsquad.house.domain.house.RentArticle;
+import com.nextsquad.house.domain.house.WantedArticle;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.nextsquad.house.domain.house.QWantedArticle.wantedArticle;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CustomWantedArticleRepositoryImpl implements CustomWantedArticleRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<WantedArticle> findByKeyword(String keyword, Pageable pageable) {
+        log.info("keyword: {}", keyword);
+        List<WantedArticle> content = jpaQueryFactory
+                .select(wantedArticle)
+                .from(wantedArticle)
+                .where(wantedArticle.isCompleted.eq(false),
+                        wantedArticle.isDeleted.eq(false),
+                        checkAddress(keyword).or(checkTitle(keyword)))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        return content;
+    }
+
+    private BooleanExpression checkAddress(String keyword) {
+        if (keyword == null) {
+            return null;
+        }
+        return wantedArticle.address.like("%" + keyword + "%");
+    }
+
+    private BooleanExpression checkTitle(String keyword) {
+        if (keyword == null) {
+            return null;
+        }
+        return wantedArticle.title.like("%" + keyword + "%");
+    }
+}

--- a/BE/house/src/main/java/com/nextsquad/house/repository/RentArticleRepository.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/RentArticleRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
-public interface RentArticleRepository extends JpaRepository<RentArticle, Long> {
+public interface RentArticleRepository extends JpaRepository<RentArticle, Long>, CustomRentArticleRepository {
     @Query("select r from RentArticle r where r.isDeleted = false and r.isCompleted = false")
     Page<RentArticle> findAllAvailable(Pageable pageable);
 

--- a/BE/house/src/main/java/com/nextsquad/house/repository/WantedArticleRepository.java
+++ b/BE/house/src/main/java/com/nextsquad/house/repository/WantedArticleRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
-public interface WantedArticleRepository extends JpaRepository<WantedArticle, Long> {
+public interface WantedArticleRepository extends JpaRepository<WantedArticle, Long>, CustomWantedArticleRepository {
     @Query("select a from WantedArticle a where a.isCompleted = false and a.isDeleted = false")
     Page<WantedArticle> findByAvailable(Pageable pageable);
     Page<WantedArticle> findByUser(User user, Pageable pageable);

--- a/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
@@ -86,8 +86,9 @@ public class RentArticleService {
         }
     }
 
-    public RentArticleListResponse getRentArticles(Pageable pageable) {
-        Page<RentArticle> rentArticles = rentArticleRepository.findAllAvailable(pageable);
+    public RentArticleListResponse getRentArticles(String keyword, Pageable pageable) {
+//        Page<RentArticle> rentArticles = rentArticleRepository.findAllAvailable(pageable);
+        Page<RentArticle> rentArticles = rentArticleRepository.findbyKeyword(keyword, pageable);
         List<RentArticleListElement> responseElements = rentArticles.stream()
                 .map(RentArticleListElement::from)
                 .collect(Collectors.toList());

--- a/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
@@ -87,17 +87,20 @@ public class RentArticleService {
     }
 
     public RentArticleListResponse getRentArticles(String keyword, Pageable pageable) {
-//        Page<RentArticle> rentArticles = rentArticleRepository.findAllAvailable(pageable);
-        Page<RentArticle> rentArticles = rentArticleRepository.findbyKeyword(keyword, pageable);
+        List<RentArticle> rentArticles = rentArticleRepository.findbyKeyword(keyword, pageable);
+        boolean hasNext = hasNext(pageable, rentArticles);
+        if (hasNext) {
+            rentArticles = rentArticles.subList(0, rentArticles.size()-1);
+        }
         List<RentArticleListElement> responseElements = rentArticles.stream()
                 .map(RentArticleListElement::from)
                 .collect(Collectors.toList());
 
-        return new RentArticleListResponse(responseElements,  hasNext(pageable, rentArticles));
+        return new RentArticleListResponse(responseElements, hasNext);
     }
 
-    private boolean hasNext(Pageable pageable, Page<RentArticle> rentArticles) {
-        return pageable.getPageNumber() < rentArticles.getTotalPages() - 1;
+    private boolean hasNext(Pageable pageable, List<RentArticle> rentArticles) {
+        return pageable.getPageSize() < rentArticles.size();
     }
 
     public RentArticleResponse getRentArticle(Long id){

--- a/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
@@ -85,8 +85,8 @@ public class RentArticleService {
         }
     }
 
-    public RentArticleListResponse getRentArticles(String keyword, Pageable pageable) {
-        List<RentArticle> rentArticles = rentArticleRepository.findByKeyword(keyword, pageable);
+    public RentArticleListResponse getRentArticles(SearchConditionDto searchCondition, Pageable pageable) {
+        List<RentArticle> rentArticles = rentArticleRepository.findByKeyword(searchCondition, pageable);
         boolean hasNext = hasNext(pageable, rentArticles);
         if (hasNext) {
             rentArticles = rentArticles.subList(0, rentArticles.size()-1);

--- a/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
@@ -7,7 +7,6 @@ import com.nextsquad.house.dto.bookmark.BookmarkRequestDto;
 import com.nextsquad.house.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -87,7 +86,7 @@ public class RentArticleService {
     }
 
     public RentArticleListResponse getRentArticles(String keyword, Pageable pageable) {
-        List<RentArticle> rentArticles = rentArticleRepository.findbyKeyword(keyword, pageable);
+        List<RentArticle> rentArticles = rentArticleRepository.findByKeyword(keyword, pageable);
         boolean hasNext = hasNext(pageable, rentArticles);
         if (hasNext) {
             rentArticles = rentArticles.subList(0, rentArticles.size()-1);

--- a/BE/house/src/main/java/com/nextsquad/house/service/WantedArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/WantedArticleService.java
@@ -5,6 +5,7 @@ import com.nextsquad.house.domain.house.WantedArticle;
 import com.nextsquad.house.domain.house.WantedArticleBookmark;
 import com.nextsquad.house.domain.user.User;
 import com.nextsquad.house.dto.GeneralResponseDto;
+import com.nextsquad.house.dto.SearchConditionDto;
 import com.nextsquad.house.dto.bookmark.BookmarkRequestDto;
 import com.nextsquad.house.dto.wantedArticle.WantedArticleElementResponse;
 import com.nextsquad.house.dto.wantedArticle.SavedWantedArticleResponse;
@@ -61,8 +62,8 @@ public class WantedArticleService {
         return WantedArticleResponse.from(article);
     }
     
-    public WantedArticleListResponse getWantedArticleList(String keyword, Pageable pageable) {
-        List<WantedArticle> wantedArticles = wantedArticleRepository.findByKeyword(keyword, pageable);
+    public WantedArticleListResponse getWantedArticleList(SearchConditionDto searchCondition, Pageable pageable) {
+        List<WantedArticle> wantedArticles = wantedArticleRepository.findByKeyword(searchCondition, pageable);
         boolean hasNext = hasNext(pageable, wantedArticles);
         if (hasNext) {
             wantedArticles = wantedArticles.subList(0, wantedArticles.size()-1);

--- a/BE/house/src/main/java/com/nextsquad/house/service/WantedArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/WantedArticleService.java
@@ -1,5 +1,6 @@
 package com.nextsquad.house.service;
 
+import com.nextsquad.house.domain.house.RentArticle;
 import com.nextsquad.house.domain.house.WantedArticle;
 import com.nextsquad.house.domain.house.WantedArticleBookmark;
 import com.nextsquad.house.domain.user.User;
@@ -60,11 +61,18 @@ public class WantedArticleService {
         return WantedArticleResponse.from(article);
     }
     
-    public WantedArticleListResponse getWantedArticleList(Pageable pageable) {
-        Page<WantedArticle> articles = wantedArticleRepository.findByAvailable(pageable);
-        List<WantedArticleElementResponse> elementResponseList = articles.stream().map(WantedArticleElementResponse::from).collect(Collectors.toList());
-        boolean hasNext = pageable.getPageNumber() < articles.getTotalPages() - 1;
+    public WantedArticleListResponse getWantedArticleList(String keyword, Pageable pageable) {
+        List<WantedArticle> wantedArticles = wantedArticleRepository.findByKeyword(keyword, pageable);
+        boolean hasNext = hasNext(pageable, wantedArticles);
+        if (hasNext) {
+            wantedArticles = wantedArticles.subList(0, wantedArticles.size()-1);
+        }
+        List<WantedArticleElementResponse> elementResponseList = wantedArticles.stream().map(WantedArticleElementResponse::from).collect(Collectors.toList());
         return new WantedArticleListResponse(elementResponseList, hasNext);
+    }
+
+    private boolean hasNext(Pageable pageable, List<?> rentArticles) {
+        return pageable.getPageSize() < rentArticles.size();
     }
 
 


### PR DESCRIPTION
## Issue
#96

## Description
- 클라이언트로부터 받는 파라미터를 SearchConditionDto로 받아 키워드 검색 및 정렬 조건 설정
- 키워드 검색 및 완료 여부 필터는 QueryDsl의 BooleanExpression 사용
- 정렬 기준 처리는 OrderSpecifier 사용
- 양수글의 경우에는 정렬 기준을 최신순으로 고정
