### PR TITLE
[backend] 글 상세보기 및 JWT 토큰 발급 시 UserId 리턴

### DIFF
--- a/BE/house/src/main/java/com/nextsquad/house/dto/JwtResponseDto.java
+++ b/BE/house/src/main/java/com/nextsquad/house/dto/JwtResponseDto.java
@@ -1,5 +1,6 @@
 package com.nextsquad.house.dto;
 
+import com.nextsquad.house.domain.user.User;
 import com.nextsquad.house.login.jwt.JwtToken;
 import com.nextsquad.house.login.jwt.Token;
 import lombok.AllArgsConstructor;
@@ -8,10 +9,11 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class JwtResponseDto {
+    private Long userId;
     private Token accessToken;
     private Token refreshToken;
 
-    public static JwtResponseDto from(JwtToken jwtToken) {
-        return new JwtResponseDto(jwtToken.getAccessToken(), jwtToken.getRefreshToken());
+    public static JwtResponseDto from(User user, JwtToken jwtToken) {
+        return new JwtResponseDto(user.getId(), jwtToken.getAccessToken(), jwtToken.getRefreshToken());
     }
 }

--- a/BE/house/src/main/java/com/nextsquad/house/dto/UserInfoDto.java
+++ b/BE/house/src/main/java/com/nextsquad/house/dto/UserInfoDto.java
@@ -7,11 +7,12 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class UserInfoDto {
+    private Long userId;
     private String displayName;
     private String profileImageUrl;
     private String gender;
 
     public static UserInfoDto from(User user) {
-        return new UserInfoDto(user.getDisplayName(), user.getProfileImageUrl(), user.getGender().name());
+        return new UserInfoDto(user.getId(), user.getDisplayName(), user.getProfileImageUrl(), user.getGender().name());
     }
 }

--- a/BE/house/src/main/java/com/nextsquad/house/service/LoginService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/LoginService.java
@@ -38,7 +38,7 @@ public class LoginService {
         JwtToken jwtToken = jwtProvider.createJwtToken(user);
         log.info("saving refresh token... key: {}, value: {}", user.getAccountId(), jwtToken.getRefreshToken().getTokenCode());
         redisService.save(user.getAccountId(), jwtToken.getRefreshToken().getTokenCode());
-        return JwtResponseDto.from(jwtToken);
+        return JwtResponseDto.from(user, jwtToken);
     }
 
     private User registerUser(UserInfo userInfo) {
@@ -62,7 +62,7 @@ public class LoginService {
                 .orElseThrow(() -> new UserNotFoundException());
         JwtToken newJwtToken = jwtProvider.createRefreshedToken(user, refreshToken);
 
-        return new JwtResponseDto(newJwtToken.getAccessToken(), newJwtToken.getRefreshToken());
+        return JwtResponseDto.from(user, newJwtToken);
 
     }
 


### PR DESCRIPTION
## Issue
#111

## Description
- 글 상세보기(양도/양수) 시 User 필드에 작성자의 userId 추가.
- JWT 토큰 발급 및 갱신 시 userId 리턴하도록 추가.
- 이를 통해 나의 userId와 게시글 작성자의 userId를 이용해 클라이언트에서 채팅 생성할 수 있도록 함