### PR TITLE
[backend] 북마크 중복 추가시 필터링, exception 메시지 수정

### DIFF
--- a/BE/house/src/main/java/com/nextsquad/house/exception/BookmarkNotFoundException.java
+++ b/BE/house/src/main/java/com/nextsquad/house/exception/BookmarkNotFoundException.java
@@ -2,6 +2,6 @@ package com.nextsquad.house.exception;
 
 public class BookmarkNotFoundException extends RuntimeException{
     public BookmarkNotFoundException() {
-        super();
+        super("해당하는 북마크를 찾을 수 없습니다.");
     }
 }

--- a/BE/house/src/main/java/com/nextsquad/house/exception/DuplicateBookmarkException.java
+++ b/BE/house/src/main/java/com/nextsquad/house/exception/DuplicateBookmarkException.java
@@ -1,0 +1,7 @@
+package com.nextsquad.house.exception;
+
+public class DuplicateBookmarkException extends RuntimeException {
+    public DuplicateBookmarkException() {
+        super("이미 북마크에 추가된 글입니다.");
+    }
+}

--- a/BE/house/src/main/java/com/nextsquad/house/exception/OauthClientNotFoundException.java
+++ b/BE/house/src/main/java/com/nextsquad/house/exception/OauthClientNotFoundException.java
@@ -2,6 +2,6 @@ package com.nextsquad.house.exception;
 
 public class OauthClientNotFoundException extends RuntimeException{
     public OauthClientNotFoundException() {
-        super("등록되어 있는 OauthClient가 아닙니다");
+        super("등록되어 있는 OAuth 서비스가 아닙니다");
     }
 }

--- a/BE/house/src/main/java/com/nextsquad/house/exception/RuntimeExceptionHandler.java
+++ b/BE/house/src/main/java/com/nextsquad/house/exception/RuntimeExceptionHandler.java
@@ -45,4 +45,9 @@ public class RuntimeExceptionHandler {
     public ResponseEntity<GeneralResponseDto> handleTokenExpiredException(TokenExpiredException e) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new GeneralResponseDto(401, "JWT 토큰이 만료되었습니다."));
     }
+
+    @ExceptionHandler(value = DuplicateBookmarkException.class)
+    public ResponseEntity<GeneralResponseDto> handleDuplicateBookmarkException(DuplicateBookmarkException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new GeneralResponseDto(400, e.getMessage()));
+    }
 }

--- a/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
@@ -7,6 +7,7 @@ import com.nextsquad.house.dto.*;
 import com.nextsquad.house.dto.bookmark.BookmarkRequestDto;
 import com.nextsquad.house.exception.ArticleNotFoundException;
 import com.nextsquad.house.exception.BookmarkNotFoundException;
+import com.nextsquad.house.exception.DuplicateBookmarkException;
 import com.nextsquad.house.exception.UserNotFoundException;
 import com.nextsquad.house.login.jwt.JwtProvider;
 import com.nextsquad.house.repository.*;
@@ -149,6 +150,11 @@ public class RentArticleService {
     public GeneralResponseDto addBookmark(BookmarkRequestDto bookmarkRequestDto) {
         User user = userRepository.findById(bookmarkRequestDto.getUserId()).orElseThrow(() -> new UserNotFoundException());
         RentArticle rentArticle = rentArticleRepository.findById(bookmarkRequestDto.getArticleId()).orElseThrow(() -> new ArticleNotFoundException());
+
+        if (rentArticleBookmarkRepository.findByUserAndRentArticle(user, rentArticle).isPresent()) {
+            throw new DuplicateBookmarkException();
+        }
+
         if (rentArticle.isDeleted()) {
             throw new IllegalArgumentException("삭제된 게시글은 추가할 수 없습니다.");
         }

--- a/BE/house/src/main/java/com/nextsquad/house/service/WantedArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/WantedArticleService.java
@@ -10,6 +10,7 @@ import com.nextsquad.house.dto.bookmark.BookmarkRequestDto;
 import com.nextsquad.house.dto.wantedArticle.*;
 import com.nextsquad.house.exception.ArticleNotFoundException;
 import com.nextsquad.house.exception.BookmarkNotFoundException;
+import com.nextsquad.house.exception.DuplicateBookmarkException;
 import com.nextsquad.house.exception.UserNotFoundException;
 import com.nextsquad.house.login.jwt.JwtProvider;
 import com.nextsquad.house.repository.UserRepository;
@@ -112,6 +113,17 @@ public class WantedArticleService {
                 .orElseThrow(() -> new ArticleNotFoundException());
         User user = userRepository.findById(bookmarkRequestDto.getUserId())
                 .orElseThrow(() -> new UserNotFoundException());
+
+        if (wantedArticleBookmarkRepository.findByUserAndWantedArticle(user, wantedArticle).isPresent()) {
+            throw new DuplicateBookmarkException();
+        }
+
+        if (wantedArticle.isDeleted()) {
+            throw new IllegalArgumentException("삭제된 게시글은 추가할 수 없습니다.");
+        }
+        if (wantedArticle.isCompleted()) {
+            throw new IllegalArgumentException("삭제된 게시글은 추가할 수 없습니다.");
+        }
 
         wantedArticleBookmarkRepository.save(new WantedArticleBookmark(user, wantedArticle));
         return new GeneralResponseDto(200, "북마크에 추가 되었습니다.");


### PR DESCRIPTION
## Issue
#128

## Description
- 북마크 중복 추가 시 이미 추가된 게시글임을 클라이언트에 고지하고 예외처리(DubplicateBookmarkException)
- 누락되어 있던 BookmarkNotFoundException의 메시지 추가
- OauthClientNotFoundException의 메시지 변경. OauthClient -> OAuth 서비스로 변경하여 타 개발 파트에서 이해하기 쉽도록 함.