### PR TITLE
Fix default profile image

### DIFF
--- a/BE/house/src/main/java/com/nextsquad/house/dto/KakaoUserInfoDto.java
+++ b/BE/house/src/main/java/com/nextsquad/house/dto/KakaoUserInfoDto.java
@@ -11,14 +11,14 @@ import java.util.Map;
 public class KakaoUserInfoDto {
     @JsonProperty("kakao_account")
     private Map<String, Object> kakaoAccount;
-    private Map<String, Object> profile;
 
 
     public UserInfo toUserInfo() {
-        this.profile = (Map<String, Object>) kakaoAccount.get("profile");
+        Map<String, String> profile = (Map<String, String>) kakaoAccount.get("profile");
+
         String email = String.valueOf(kakaoAccount.get("email"));
-        String nickname = String.valueOf(profile.get("nickname"));
-        String profileImageUrl = String.valueOf(profile.get("profile_image_url"));
+        String nickname = profile.get("nickname");
+        String profileImageUrl = profile.get("profile_image_url");
 
         return new UserInfo(email, nickname, profileImageUrl, OauthClientType.KAKAO);
     }

--- a/BE/house/src/main/java/com/nextsquad/house/login/jwt/JwtTokenType.java
+++ b/BE/house/src/main/java/com/nextsquad/house/login/jwt/JwtTokenType.java
@@ -1,7 +1,7 @@
 package com.nextsquad.house.login.jwt;
 
 public enum JwtTokenType {
-    ACCESS(5000), // 900000
+    ACCESS(900000),
     REFRESH(604800000);
 
     private final int duration;

--- a/BE/house/src/main/java/com/nextsquad/house/login/oauth/KakaoOauthClient.java
+++ b/BE/house/src/main/java/com/nextsquad/house/login/oauth/KakaoOauthClient.java
@@ -59,10 +59,5 @@ public class KakaoOauthClient extends OauthClient {
     protected String parseToken(String rawToken) {
         return String.format("Bearer %s", rawToken);
     }
-
-    protected UserInfo convertToUserInfoFrom(String rawInfo) {
-        Map<String, String> infoMap = new Gson().fromJson(rawInfo, Map.class);
-        return new UserInfo(infoMap.get("email"), infoMap.get("nickname"), null, OauthClientType.KAKAO);
-    }
 }
 

--- a/BE/house/src/main/java/com/nextsquad/house/login/userinfo/UserInfo.java
+++ b/BE/house/src/main/java/com/nextsquad/house/login/userinfo/UserInfo.java
@@ -15,13 +15,14 @@ public class UserInfo {
 
     protected String profileImageUrl;
     private OauthClientType oauthClientType;
+    private static final String DEFAULT_PROFILE_IMAGE = "https://house-image-bucket.s3.ap-northeast-2.amazonaws.com/default_profile.png";
 
     public UserInfo(String accountId, String displayName, String profileImageUrl, OauthClientType oauthClientType) {
         String identifier = String.valueOf(new Random().nextInt(9999));
 
         this.accountId = accountId;
         this.displayName = displayName + identifier;
-        this.profileImageUrl = profileImageUrl;
+        this.profileImageUrl = profileImageUrl != null ? profileImageUrl : DEFAULT_PROFILE_IMAGE;
         this.oauthClientType = oauthClientType;
     }
 


### PR DESCRIPTION
## Commit
#130

## Description
-  Kakako OAuth 클라이언트에서 이미지가 안 들어올 때 "null" 문자열로 들어오던 것을 NULL로 변경
- UserInfo.toUser() 메서드에서 인자로 들어오는 profileImageUrl이 NULL일 경우 기본 이미지를 할당하도록 변경