### PR TITLE
[backend] 글 삭제/수정시 해당 글쓴이만 가능하도록 로직 수정

### DIFF
--- a/BE/house/src/main/java/com/nextsquad/house/controller/RentArticleController.java
+++ b/BE/house/src/main/java/com/nextsquad/house/controller/RentArticleController.java
@@ -34,18 +34,18 @@ public class RentArticleController {
     }
 
     @PatchMapping("/{id}")
-    public ResponseEntity<GeneralResponseDto> modifyRentArticle(@PathVariable Long id, @RequestBody RentArticleRequest request) {
-        return ResponseEntity.ok(rentArticleService.modifyRentArticle(id, request));
+    public ResponseEntity<GeneralResponseDto> modifyRentArticle(@PathVariable Long id, @RequestBody RentArticleRequest request, @RequestHeader(value = "access-token") String token) {
+        return ResponseEntity.ok(rentArticleService.modifyRentArticle(id, request, token));
     }
 
     @PatchMapping("/{id}/isCompleted")
-    public ResponseEntity<GeneralResponseDto> toggleIsCompleted(@PathVariable Long id) {
-        return ResponseEntity.ok(rentArticleService.toggleIsCompleted(id));
+    public ResponseEntity<GeneralResponseDto> toggleIsCompleted(@PathVariable Long id, @RequestHeader(value = "access-token") String token) {
+        return ResponseEntity.ok(rentArticleService.toggleIsCompleted(id, token));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<GeneralResponseDto> deleteArticle(@PathVariable Long id) {
-        return ResponseEntity.ok(rentArticleService.deleteArticle(id));
+    public ResponseEntity<GeneralResponseDto> deleteArticle(@PathVariable Long id, @RequestHeader(value = "access-token") String token) {
+        return ResponseEntity.ok(rentArticleService.deleteArticle(id, token));
     }
 
     @PostMapping("/bookmarks")

--- a/BE/house/src/main/java/com/nextsquad/house/controller/RentArticleController.java
+++ b/BE/house/src/main/java/com/nextsquad/house/controller/RentArticleController.java
@@ -49,13 +49,13 @@ public class RentArticleController {
     }
 
     @PostMapping("/bookmarks")
-    public ResponseEntity<GeneralResponseDto> addBookmark(@RequestBody BookmarkRequestDto bookmarkRequestDto){
-        return ResponseEntity.ok(rentArticleService.addBookmark(bookmarkRequestDto));
+    public ResponseEntity<GeneralResponseDto> addBookmark(@RequestBody BookmarkRequestDto bookmarkRequestDto, @RequestHeader(value = "access-token") String token){
+        return ResponseEntity.ok(rentArticleService.addBookmark(bookmarkRequestDto, token));
     }
 
     @DeleteMapping("/bookmarks")
-    public ResponseEntity<GeneralResponseDto> deleteBookmark(@RequestBody BookmarkRequestDto bookmarkRequestDto) {
-        return ResponseEntity.ok(rentArticleService.deleteBookmark(bookmarkRequestDto));
+    public ResponseEntity<GeneralResponseDto> deleteBookmark(@RequestBody BookmarkRequestDto bookmarkRequestDto, @RequestHeader(value = "access-token") String token) {
+        return ResponseEntity.ok(rentArticleService.deleteBookmark(bookmarkRequestDto, token));
     }
 
 }

--- a/BE/house/src/main/java/com/nextsquad/house/controller/WantedArticleController.java
+++ b/BE/house/src/main/java/com/nextsquad/house/controller/WantedArticleController.java
@@ -48,13 +48,13 @@ public class WantedArticleController {
     }
 
     @PostMapping("/bookmarks")
-    public ResponseEntity<GeneralResponseDto> addWantedBookmark(@RequestBody BookmarkRequestDto bookmarkRequestDto) {
-        return ResponseEntity.ok(wantedArticleService.addWantedBookmark(bookmarkRequestDto));
+    public ResponseEntity<GeneralResponseDto> addWantedBookmark(@RequestBody BookmarkRequestDto bookmarkRequestDto, @RequestHeader(value = "access-token") String token) {
+        return ResponseEntity.ok(wantedArticleService.addWantedBookmark(bookmarkRequestDto, token));
     }
 
     @DeleteMapping("/bookmarks")
-    public ResponseEntity<GeneralResponseDto> deleteWantedBookmark(@RequestBody BookmarkRequestDto bookmarkRequestDto) {
-        return ResponseEntity.ok(wantedArticleService.deleteWantedBookmark(bookmarkRequestDto));
+    public ResponseEntity<GeneralResponseDto> deleteWantedBookmark(@RequestBody BookmarkRequestDto bookmarkRequestDto, @RequestHeader(value = "access-token") String token) {
+        return ResponseEntity.ok(wantedArticleService.deleteWantedBookmark(bookmarkRequestDto, token));
     }
 
 }

--- a/BE/house/src/main/java/com/nextsquad/house/controller/WantedArticleController.java
+++ b/BE/house/src/main/java/com/nextsquad/house/controller/WantedArticleController.java
@@ -27,13 +27,13 @@ public class WantedArticleController {
 
 
     @GetMapping("/{id}")
-    public ResponseEntity<WantedArticleResponse> getWantedArticle(@PathVariable Long id, @RequestHeader(value = "access-token")String token) {
+    public ResponseEntity<WantedArticleResponse> getWantedArticle(@PathVariable Long id, @RequestHeader(value = "access-token") String token) {
         return ResponseEntity.ok(wantedArticleService.getWantedArticle(id, token));
     }
 
     @PatchMapping("/{id}")
-    public ResponseEntity<GeneralResponseDto> updateWantedArticle(@PathVariable Long id, @RequestBody WantedArticleRequest request) {
-        return ResponseEntity.ok(wantedArticleService.updateWantedArticle(id, request));
+    public ResponseEntity<GeneralResponseDto> updateWantedArticle(@PathVariable Long id, @RequestBody WantedArticleRequest request, @RequestHeader(value = "access-token") String token) {
+        return ResponseEntity.ok(wantedArticleService.updateWantedArticle(id, request, token));
     }
 
     @GetMapping
@@ -43,8 +43,8 @@ public class WantedArticleController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<GeneralResponseDto> deleteWantedArticle(@PathVariable Long id){
-        return ResponseEntity.ok(wantedArticleService.deleteWantedArticle(id));
+    public ResponseEntity<GeneralResponseDto> deleteWantedArticle(@PathVariable Long id, @RequestHeader(value = "access-token") String token){
+        return ResponseEntity.ok(wantedArticleService.deleteWantedArticle(id, token));
     }
 
     @PostMapping("/bookmarks")

--- a/BE/house/src/main/java/com/nextsquad/house/exception/AccessDeniedException.java
+++ b/BE/house/src/main/java/com/nextsquad/house/exception/AccessDeniedException.java
@@ -1,0 +1,8 @@
+package com.nextsquad.house.exception;
+
+public class AccessDeniedException extends RuntimeException {
+
+    public AccessDeniedException() {
+        super("접근 권한이 없습니다.");
+    }
+}

--- a/BE/house/src/main/java/com/nextsquad/house/exception/RuntimeExceptionHandler.java
+++ b/BE/house/src/main/java/com/nextsquad/house/exception/RuntimeExceptionHandler.java
@@ -50,4 +50,9 @@ public class RuntimeExceptionHandler {
     public ResponseEntity<GeneralResponseDto> handleDuplicateBookmarkException(DuplicateBookmarkException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new GeneralResponseDto(400, e.getMessage()));
     }
+
+    @ExceptionHandler(value = AccessDeniedException.class)
+    public ResponseEntity<GeneralResponseDto> handleAccessDeniedException(AccessDeniedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new GeneralResponseDto(401, e.getMessage()));
+    }
 }

--- a/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
@@ -5,10 +5,7 @@ import com.nextsquad.house.domain.house.*;
 import com.nextsquad.house.domain.user.User;
 import com.nextsquad.house.dto.*;
 import com.nextsquad.house.dto.bookmark.BookmarkRequestDto;
-import com.nextsquad.house.exception.ArticleNotFoundException;
-import com.nextsquad.house.exception.BookmarkNotFoundException;
-import com.nextsquad.house.exception.DuplicateBookmarkException;
-import com.nextsquad.house.exception.UserNotFoundException;
+import com.nextsquad.house.exception.*;
 import com.nextsquad.house.login.jwt.JwtProvider;
 import com.nextsquad.house.repository.*;
 import lombok.RequiredArgsConstructor;
@@ -204,6 +201,16 @@ public class RentArticleService {
     private void saveHouseImage(RentArticle rentArticle, List<String> houseImageUrls) {
         for (int i = 0; i < houseImageUrls.size(); i++) {
             houseImageRepository.save(new HouseImage(houseImageUrls.get(i), rentArticle, i));
+        }
+    }
+
+    private void authorizeArticleOwner(String accessToken, RentArticle article) {
+        Long loggedInId = jwtProvider.decode(accessToken).getClaim("id").asLong();
+        User user = userRepository.findById(loggedInId)
+                .orElseThrow(UserNotFoundException::new);
+
+        if (!user.equals(article.getUser())) {
+            throw new AccessDeniedException();
         }
     }
 }

--- a/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
@@ -136,16 +136,22 @@ public class RentArticleService {
         return new RentArticleResponse(rentArticle, isBookmarked);
     }
 
-    public GeneralResponseDto toggleIsCompleted(Long id) {
+    public GeneralResponseDto toggleIsCompleted(Long id, String accessToken) {
         RentArticle rentArticle = rentArticleRepository.findById(id)
                 .orElseThrow(() -> new ArticleNotFoundException());
+
+        authorizeArticleOwner(accessToken, rentArticle);
+
         rentArticle.toggleIsCompleted();
         return new GeneralResponseDto(200, "게시글 상태가 변경되었습니다.");
     }
 
-    public GeneralResponseDto deleteArticle(Long id) {
+    public GeneralResponseDto deleteArticle(Long id, String accessToken) {
         RentArticle rentArticle = rentArticleRepository.findById(id)
                 .orElseThrow(() -> new ArticleNotFoundException());
+
+        authorizeArticleOwner(accessToken, rentArticle);
+
         rentArticle.markAsDeleted();
         rentArticleBookmarkRepository.deleteByRentArticle(rentArticle);
         return new GeneralResponseDto(200, "게시글이 삭제되었습니다.");
@@ -180,10 +186,12 @@ public class RentArticleService {
         return new GeneralResponseDto(200, "북마크가 삭제되었습니다.");
     }
 
-    public GeneralResponseDto modifyRentArticle(Long id, RentArticleRequest request) {
+    public GeneralResponseDto modifyRentArticle(Long id, RentArticleRequest request, String accessToken) {
         log.info("updating {}... ", request.getTitle());
         RentArticle rentArticle = rentArticleRepository.findById(id)
                 .orElseThrow(() -> new ArticleNotFoundException());
+
+        authorizeArticleOwner(accessToken, rentArticle);
 
         facilityInHomeRepository.deleteAllByRentArticle(rentArticle);
         securityInHomeRepository.deleteAllByRentArticle(rentArticle);

--- a/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/RentArticleService.java
@@ -157,8 +157,10 @@ public class RentArticleService {
         return new GeneralResponseDto(200, "게시글이 삭제되었습니다.");
     }
 
-    public GeneralResponseDto addBookmark(BookmarkRequestDto bookmarkRequestDto) {
-        User user = userRepository.findById(bookmarkRequestDto.getUserId()).orElseThrow(() -> new UserNotFoundException());
+    public GeneralResponseDto addBookmark(BookmarkRequestDto bookmarkRequestDto, String token) {
+        Long loginedId = jwtProvider.decode(token).getClaim("id").asLong();
+
+        User user = userRepository.findById(loginedId).orElseThrow(() -> new UserNotFoundException());
         RentArticle rentArticle = rentArticleRepository.findById(bookmarkRequestDto.getArticleId()).orElseThrow(() -> new ArticleNotFoundException());
 
         if (rentArticleBookmarkRepository.findByUserAndRentArticle(user, rentArticle).isPresent()) {
@@ -175,8 +177,10 @@ public class RentArticleService {
         return new GeneralResponseDto(200, "북마크에 추가 되었습니다.");
     }
 
-    public GeneralResponseDto deleteBookmark(BookmarkRequestDto bookmarkRequestDto) {
-        User user = userRepository.findById(bookmarkRequestDto.getUserId())
+    public GeneralResponseDto deleteBookmark(BookmarkRequestDto bookmarkRequestDto, String token) {
+        Long loginedId = jwtProvider.decode(token).getClaim("id").asLong();
+
+        User user = userRepository.findById(loginedId)
                 .orElseThrow(() -> new UserNotFoundException());
         RentArticle rentArticle = rentArticleRepository.findById(bookmarkRequestDto.getArticleId())
                 .orElseThrow(() -> new ArticleNotFoundException());

--- a/BE/house/src/main/java/com/nextsquad/house/service/WantedArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/WantedArticleService.java
@@ -121,10 +121,13 @@ public class WantedArticleService {
         return new GeneralResponseDto(200, "게시글이 수정되었습니다.");
     }
 
-    public GeneralResponseDto addWantedBookmark(BookmarkRequestDto bookmarkRequestDto) {
+    public GeneralResponseDto addWantedBookmark(BookmarkRequestDto bookmarkRequestDto, String token) {
         WantedArticle wantedArticle = wantedArticleRepository.findById(bookmarkRequestDto.getArticleId())
                 .orElseThrow(() -> new ArticleNotFoundException());
-        User user = userRepository.findById(bookmarkRequestDto.getUserId())
+
+        Long loginedId = jwtProvider.decode(token).getClaim("id").asLong();
+
+        User user = userRepository.findById(loginedId)
                 .orElseThrow(() -> new UserNotFoundException());
 
         if (wantedArticleBookmarkRepository.findByUserAndWantedArticle(user, wantedArticle).isPresent()) {
@@ -142,10 +145,12 @@ public class WantedArticleService {
         return new GeneralResponseDto(200, "북마크에 추가 되었습니다.");
     }
 
-    public GeneralResponseDto deleteWantedBookmark(BookmarkRequestDto bookmarkRequestDto) {
+    public GeneralResponseDto deleteWantedBookmark(BookmarkRequestDto bookmarkRequestDto, String token) {
+        Long loginedId = jwtProvider.decode(token).getClaim("id").asLong();
+
         WantedArticle wantedArticle = wantedArticleRepository.findById(bookmarkRequestDto.getArticleId())
                 .orElseThrow(() -> new ArticleNotFoundException());
-        User user = userRepository.findById(bookmarkRequestDto.getUserId())
+        User user = userRepository.findById(loginedId)
                 .orElseThrow(() -> new UserNotFoundException());
         WantedArticleBookmark bookmark = wantedArticleBookmarkRepository.findByUserAndWantedArticle(user, wantedArticle)
                 .orElseThrow(() -> new BookmarkNotFoundException());

--- a/BE/house/src/main/java/com/nextsquad/house/service/WantedArticleService.java
+++ b/BE/house/src/main/java/com/nextsquad/house/service/WantedArticleService.java
@@ -1,6 +1,7 @@
 package com.nextsquad.house.service;
 
 import com.auth0.jwt.interfaces.DecodedJWT;
+import com.nextsquad.house.domain.house.RentArticle;
 import com.nextsquad.house.domain.house.WantedArticle;
 import com.nextsquad.house.domain.house.WantedArticleBookmark;
 import com.nextsquad.house.domain.user.User;
@@ -8,10 +9,7 @@ import com.nextsquad.house.dto.GeneralResponseDto;
 import com.nextsquad.house.dto.SearchConditionDto;
 import com.nextsquad.house.dto.bookmark.BookmarkRequestDto;
 import com.nextsquad.house.dto.wantedArticle.*;
-import com.nextsquad.house.exception.ArticleNotFoundException;
-import com.nextsquad.house.exception.BookmarkNotFoundException;
-import com.nextsquad.house.exception.DuplicateBookmarkException;
-import com.nextsquad.house.exception.UserNotFoundException;
+import com.nextsquad.house.exception.*;
 import com.nextsquad.house.login.jwt.JwtProvider;
 import com.nextsquad.house.repository.UserRepository;
 import com.nextsquad.house.repository.WantedArticleBookmarkRepository;
@@ -102,17 +100,22 @@ public class WantedArticleService {
     }
 
 
-    public GeneralResponseDto deleteWantedArticle(Long id) {
+    public GeneralResponseDto deleteWantedArticle(Long id, String accessToken) {
         WantedArticle wantedArticle = wantedArticleRepository.findById(id)
                 .orElseThrow(() -> new ArticleNotFoundException());
+
+        authorizeArticleOwner(accessToken, wantedArticle);
+
         wantedArticle.markAsDeleted();
         wantedArticleBookmarkRepository.deleteByWantedArticle(wantedArticle);
         return new GeneralResponseDto(200, "게시글이 삭제되었습니다.");
     }
     
-    public GeneralResponseDto updateWantedArticle(Long id, WantedArticleRequest request) {
+    public GeneralResponseDto updateWantedArticle(Long id, WantedArticleRequest request, String accessToken) {
         WantedArticle article = wantedArticleRepository.findById(id)
                 .orElseThrow(() -> new ArticleNotFoundException());
+
+        authorizeArticleOwner(accessToken, article);
 
         article.modifyArticle(request);
         return new GeneralResponseDto(200, "게시글이 수정되었습니다.");
@@ -149,5 +152,15 @@ public class WantedArticleService {
 
         wantedArticleBookmarkRepository.delete(bookmark);
         return new GeneralResponseDto(200, "북마크가 삭제되었습니다.");
+    }
+
+    private void authorizeArticleOwner(String accessToken, WantedArticle article) {
+        Long loggedInId = jwtProvider.decode(accessToken).getClaim("id").asLong();
+        User user = userRepository.findById(loggedInId)
+                .orElseThrow(UserNotFoundException::new);
+
+        if (!user.equals(article.getUser())) {
+            throw new AccessDeniedException();
+        }
     }
 }

--- a/BE/house/src/test/java/com/nextsquad/house/acceptance/rentArticle/RentArticleAcceptanceTest.java
+++ b/BE/house/src/test/java/com/nextsquad/house/acceptance/rentArticle/RentArticleAcceptanceTest.java
@@ -174,6 +174,33 @@ public class RentArticleAcceptanceTest {
     }
 
     @Test
+    void 다른_유저의_게시글을_수정하면_예외가_발생한다(){
+        List<String> images = new ArrayList<>();
+        List<String> facilities = new ArrayList<>();
+        List<String> securityFacilities = new ArrayList<>();
+        images.add("테스트 이미지 주소");
+        RentArticleRequest request = new RentArticleRequest(1L, "테스트 주소", "테스트 주소 디테일", "주소 설명",
+                109.32, 2342.44, "제목", "내용", "MONTHLY", "ONEROOM", facilities, securityFacilities,
+                0, 340000, 50000, "전기 포함", LocalDate.now(), LocalDate.of(2023, 9, 10),
+                5, 2, false, false, false, images);
+        given(documentationSpec)
+                .filter(document("modify-rent-article", preprocessRequest(prettyPrint()), preprocessResponse(prettyPrint())))
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("access-token", jwtToken.getAccessToken().getTokenCode())
+                .body(request)
+
+                .when()
+                .patch("/houses/rent/13")
+
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value())
+                .assertThat()
+                .body("code", equalTo(401))
+                .body("message", equalTo("접근 권한이 없습니다."));
+    }
+
+    @Test
     void id가_11번인_양도글을_거래완료_처리한다(){
         given(documentationSpec)
                 .filter(document("completed-rent-article", preprocessRequest(prettyPrint()), preprocessResponse(prettyPrint())))
@@ -192,6 +219,24 @@ public class RentArticleAcceptanceTest {
     }
 
     @Test
+    void 다른_유저의_게시글을_완료_처리하면_예외가_발생한다(){
+        given(documentationSpec)
+                .filter(document("completed-rent-article", preprocessRequest(prettyPrint()), preprocessResponse(prettyPrint())))
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("access-token", jwtToken.getAccessToken().getTokenCode())
+
+                .when()
+                .patch("/houses/rent/13/isCompleted")
+
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value())
+                .assertThat()
+                .body("code", equalTo(401))
+                .body("message", equalTo("접근 권한이 없습니다."));
+    }
+
+    @Test
     void id가_11번인_양도글을_삭제한다(){
         given(documentationSpec)
                 .filter(document("deleted-rent-article", preprocessRequest(prettyPrint()), preprocessResponse(prettyPrint())))
@@ -207,6 +252,24 @@ public class RentArticleAcceptanceTest {
                 .assertThat()
                 .body("code", equalTo(200))
                 .body("message", equalTo("게시글이 삭제되었습니다."));
+    }
+
+    @Test
+    void 다른_유저의_게시글을_삭제하면_예외가_발생한다(){
+        given(documentationSpec)
+                .filter(document("deleted-rent-article", preprocessRequest(prettyPrint()), preprocessResponse(prettyPrint())))
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("access-token", jwtToken.getAccessToken().getTokenCode())
+
+                .when()
+                .delete("/houses/rent/13")
+
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value())
+                .assertThat()
+                .body("code", equalTo(401))
+                .body("message", equalTo("접근 권한이 없습니다."));
     }
 
     @Test

--- a/BE/house/src/test/java/com/nextsquad/house/acceptance/wantedArticle/WantedArticleAcceptanceTest.java
+++ b/BE/house/src/test/java/com/nextsquad/house/acceptance/wantedArticle/WantedArticleAcceptanceTest.java
@@ -2,7 +2,6 @@ package com.nextsquad.house.acceptance.wantedArticle;
 
 import com.nextsquad.house.dto.bookmark.BookmarkRequestDto;
 import com.nextsquad.house.dto.wantedArticle.WantedArticleRequest;
-import com.nextsquad.house.exception.AccessDeniedException;
 import com.nextsquad.house.login.jwt.JwtProvider;
 import com.nextsquad.house.login.jwt.JwtToken;
 import com.nextsquad.house.repository.UserRepository;

--- a/BE/house/src/test/java/com/nextsquad/house/acceptance/wantedArticle/WantedArticleAcceptanceTest.java
+++ b/BE/house/src/test/java/com/nextsquad/house/acceptance/wantedArticle/WantedArticleAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.nextsquad.house.acceptance.wantedArticle;
 
 import com.nextsquad.house.dto.bookmark.BookmarkRequestDto;
 import com.nextsquad.house.dto.wantedArticle.WantedArticleRequest;
+import com.nextsquad.house.exception.AccessDeniedException;
 import com.nextsquad.house.login.jwt.JwtProvider;
 import com.nextsquad.house.login.jwt.JwtToken;
 import com.nextsquad.house.repository.UserRepository;
@@ -141,6 +142,23 @@ public class WantedArticleAcceptanceTest {
     }
 
     @Test
+    void 다른_유저의_게시글을_삭제하면_예외가_발생한다(){
+        given(documentationSpec)
+                .filter(document("delete-wanted-article", preprocessRequest(prettyPrint()), preprocessResponse(prettyPrint())))
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .header("access-token", jwtToken.getAccessToken().getTokenCode())
+
+                .when()
+                .delete("houses/wanted/13")
+
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value())
+                .assertThat()
+                .body("code", equalTo(401))
+                .body("message", equalTo("접근 권한이 없습니다."));
+    }
+
+    @Test
     void id가_2번인_양수글을_수정한다(){
         WantedArticleRequest request = new WantedArticleRequest(1L, "주소 수정 테스트", "제목 수정 테스트"
         , "내용 수정 테스트", LocalDate.now(), LocalDate.now(), 500, 20000);
@@ -159,6 +177,27 @@ public class WantedArticleAcceptanceTest {
                 .assertThat()
                 .body("code", equalTo(200))
                 .body("message", equalTo("게시글이 수정되었습니다."));
+    }
+
+    @Test
+    void 다른_유저의_게시글을_수정하면_예외가_발생한다(){
+        WantedArticleRequest request = new WantedArticleRequest(1L, "주소 수정 테스트", "제목 수정 테스트"
+                , "내용 수정 테스트", LocalDate.now(), LocalDate.now(), 500, 20000);
+        given(documentationSpec)
+                .filter(document("update-wanted-article", preprocessRequest(prettyPrint()), preprocessResponse(prettyPrint())))
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("access-token", jwtToken.getAccessToken().getTokenCode())
+                .body(request)
+
+                .when()
+                .patch("houses/wanted/13")
+
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value())
+                .assertThat()
+                .body("code", equalTo(401))
+                .body("message", equalTo("접근 권한이 없습니다."));
     }
 
     @Test


### PR DESCRIPTION
###Description
- 양수글, 양도글 삭제/수정 시 해당 글쓴이만 가능하도록 로직 수정
- 북마크 추가/삭제 시 token에서 가져온 유저 아이디 사용하도록 수정